### PR TITLE
[BZ 1042828] - CallTimeDataManager manager should be able to expose raw data, not just the aggregates

### DIFF
--- a/modules/core/domain/src/main/java/org/rhq/core/domain/measurement/calltime/CallTimeDataValue.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/measurement/calltime/CallTimeDataValue.java
@@ -63,6 +63,19 @@ import org.jetbrains.annotations.Nullable;
         + "AND value.beginTime >= :beginTime "
         + "AND value.endTime <= :endTime "
         + "GROUP BY key.callDestination "),
+    @NamedQuery(name = CallTimeDataValue.QUERY_FIND_RAW_FOR_RESOURCE, query = "SELECT new org.rhq.core.domain.measurement.calltime.CallTimeDataComposite("
+        + "key.callDestination, "
+        + "value.minimum, "
+        + "value.maximum, "
+        + "value.total, "
+        + "value.count, "
+        + "value.total / value.count) "
+        + "FROM CallTimeDataValue value "
+        + "WHERE key.schedule.id = :scheduleId "
+        + "AND value.count != 0 "
+        + "AND value.minimum != -1 "
+        + "AND value.beginTime >= :beginTime "
+        + "AND value.endTime <= :endTime "),
     @NamedQuery(name = CallTimeDataValue.QUERY_DELETE_BY_RESOURCES, query = "DELETE CallTimeDataValue ctdv WHERE ctdv.key IN ( SELECT ctdk.id FROM CallTimeDataKey ctdk WHERE ctdk.schedule.resource.id IN ( :resourceIds ) )") })
 @SequenceGenerator(allocationSize = org.rhq.core.domain.util.Constants.ALLOCATION_SIZE, name = "RHQ_CALLTIME_DATA_VALUE_ID_SEQ", sequenceName = "RHQ_CALLTIME_DATA_VALUE_ID_SEQ")
 @Table(name = "RHQ_CALLTIME_DATA_VALUE")
@@ -71,6 +84,7 @@ public class CallTimeDataValue implements Serializable {
 
     public static final String QUERY_FIND_COMPOSITES_FOR_RESOURCE = "CallTimeDataValue.findCompositesForResource";
     public static final String QUERY_DELETE_BY_RESOURCES = "CallTimeDataValue.deleteByResources";
+    public static final String QUERY_FIND_RAW_FOR_RESOURCE = "CallTimeDataValue.findRawForResource";
 
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "RHQ_CALLTIME_DATA_VALUE_ID_SEQ")
     @Id

--- a/modules/enterprise/server/jar/intentional-api-changes-since-4.9.0.xml
+++ b/modules/enterprise/server/jar/intentional-api-changes-since-4.9.0.xml
@@ -113,4 +113,11 @@
     <justification>Adding a method to a remote API interface is safe. This is newly implemented functionality.</justification>
   </difference>
 
+  <difference>
+    <className>org/rhq/enterprise/server/measurement/CallTimeDataManagerRemote</className>
+    <differenceType>7012</differenceType>  <!-- method added to an interface -->
+    <method>org.rhq.core.domain.util.PageList findCallTimeDataRawForResource(org.rhq.core.domain.auth.Subject, int, long, long, org.rhq.core.domain.util.PageControl)</method>
+    <justification>Adding a method to a remote API interface is safe. This is newly implemented functionality.</justification>
+  </difference>
+
 </differences>

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/measurement/CallTimeDataManagerRemote.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/measurement/CallTimeDataManagerRemote.java
@@ -41,5 +41,16 @@ public interface CallTimeDataManagerRemote {
      */
     PageList<CallTimeDataComposite> findCallTimeDataForResource(Subject subject, int scheduleId, long beginTime,
         long endTime, PageControl pc);
+    /**
+     * Compared to {@link #findCallTimeDataForResource(Subject, int, long, long, PageControl)}
+     * this method returns more detailed call-time data not grouped by callDestination.
+     * @param subject
+     * @param scheduleId The MeasurementSchedule id
+     * @param beginTime in millis
+     * @param endTime in millis
+     * @param pc
+     * @return not null
+     */
+    PageList<CallTimeDataComposite> findCallTimeDataRawForResource(Subject subject, int scheduleId, long beginTime, long endTime, PageControl pc);
 
 }


### PR DESCRIPTION
Raw data are now exposed via findCallTimeDataRawForResource. We don't return
RAW data (meaning per-request entities), because RHQ server does not store
it. Instead it stores already aggregated data - aggregation per
callDestination happens on agent when sending metric report. At maximum (as
minimum collection interval is 1m) user can get aggregated data for requests
within 1 minute per callDestination). This data are considered as RAW
because it's rawest we have.
