### PR TITLE
[BZ 958922] RFE: support for passing plugin config when creating child

### DIFF
--- a/modules/integration-tests/rest-api/src/test/java/org/rhq/modules/integrationTests/restApi/AbstractBase.java
+++ b/modules/integration-tests/rest-api/src/test/java/org/rhq/modules/integrationTests/restApi/AbstractBase.java
@@ -112,6 +112,34 @@ public abstract class AbstractBase {
 
         }
     }
+    protected int findIdOfARealEAP6() {
+        // Find an EAP 6 server
+        List<Map<String,Object>> resources =
+        given()
+            .header(acceptJson)
+            .queryParam("q","EAP (")
+            .queryParam("category","SERVER")
+        .expect()
+            .statusCode(200)
+            .log().ifError()
+        .when()
+            .get("/resource")
+        .jsonPath().getList("$");
+
+        assert resources.size() > 0 : "No real EAP6 server found in inventory";
+
+        int as7Id = (Integer)resources.get(0).get("resourceId");
+        // try to find stock EAP6 
+        if (resources.size() > 1) {
+          for (Map<String,Object> res : resources) {
+            if (!res.get("resourceName").toString().contains("RHQ Server")) {
+              as7Id = (Integer)res.get("resourceId");
+              break;
+            }
+          }
+        }
+        return as7Id;
+    }
 
     protected int findIdOfARealPlatform() {
         List res =

--- a/modules/integration-tests/rest-api/src/test/java/org/rhq/modules/integrationTests/restApi/ContentTest.java
+++ b/modules/integration-tests/rest-api/src/test/java/org/rhq/modules/integrationTests/restApi/ContentTest.java
@@ -171,30 +171,8 @@ public class ContentTest extends AbstractBase {
             .getString("value");
 
         // Find an EAP 6 server
-        List<Map<String,Object>> resources =
-        given()
-            .header(acceptJson)
-            .queryParam("q","EAP (")
-            .queryParam("category","SERVER")
-        .expect()
-            .statusCode(200)
-            .log().ifError()
-        .when()
-            .get("/resource")
-        .jsonPath().getList("$");
+        int as7Id = findIdOfARealEAP6();
 
-        assert resources.size()>0;
-
-        int as7Id = (Integer)resources.get(0).get("resourceId");
-        // try to find stock EAP6 
-        if (resources.size() > 1) {
-          for (Map<String,Object> res : resources) {
-            if (!res.get("resourceName").toString().contains("RHQ Server")) {
-              as7Id = (Integer)res.get("resourceId");
-              break;
-            }
-          }
-        }
         int createdResourceId=-1;
 
         // create child of eap6 as deployment


### PR DESCRIPTION
resources

Now we support all 4 possible 'ways' to create a resource on RHQ
1. regular resource (was already implemented before) - when REST client create
   resources that agent would have discovered. Such resources is not possible
   to create via UI or CLI
2. content-based resources (was already implemented before)
3. resource children: similar to content-based resources, UI analogy is
   "Create Child". Create child history exists. - possible resource duplicities
   are handled on agent side.
4. manual resources: Resources that could be only manually Imported from UI,
   create child history does not exist for those, and their resource key highly
   depends on given pluginConfiguration (although resourceName can be passed).
   Duplicates are handled on server side, since underlying API does not report
   an error when manually imported resource already exists.

For 3. and 4. there's client can optinaly pass only required plugin/resource
configurations. In rest api code, we retrieve all the defaults from resource
type and then apply passed values on top.
