### PR TITLE
[BZ 1070668] Incorrect default configuration of RHQDS resource

### DIFF
--- a/modules/common/jboss-as-dmr-client/src/main/java/org/rhq/common/jbossas/client/controller/DatasourceJBossASClient.java
+++ b/modules/common/jboss-as-dmr-client/src/main/java/org/rhq/common/jbossas/client/controller/DatasourceJBossASClient.java
@@ -326,6 +326,7 @@ public class DatasourceJBossASClient extends JBossASClient {
      * @param name
      * @param blockingTimeoutWaitMillis
      * @param driverName
+     * @param xaDataSourceClass
      * @param exceptionSorterClassName
      * @param idleTimeoutMinutes
      * @param minPoolSize
@@ -342,7 +343,7 @@ public class DatasourceJBossASClient extends JBossASClient {
      *
      * @return the request that can be used to create the XA datasource
      */
-    public ModelNode createNewXADatasourceRequest(String name, int blockingTimeoutWaitMillis, String driverName,
+    public ModelNode createNewXADatasourceRequest(String name, int blockingTimeoutWaitMillis, String driverName, String xaDataSourceClass,
         String exceptionSorterClassName, int idleTimeoutMinutes, int minPoolSize, int maxPoolSize, Boolean noRecovery,
         Boolean noTxSeparatePool, int preparedStatementCacheSize, String recoveryPluginClassName,
         String securityDomain, String staleConnectionCheckerClassName, String transactionIsolation,
@@ -352,7 +353,8 @@ public class DatasourceJBossASClient extends JBossASClient {
 
         String dmrTemplate = "" //
             + "{" //
-            + "\"blocking-timeout-wait-millis\" => %dL " //
+            + "\"xa-datasource-class\" => \"%s\""
+            + ", \"blocking-timeout-wait-millis\" => %dL " //
             + ", \"driver-name\" => \"%s\" " //
             + ", \"exception-sorter-class-name\" => \"%s\" " //
             + ", \"idle-timeout-minutes\" => %dL " //
@@ -371,7 +373,7 @@ public class DatasourceJBossASClient extends JBossASClient {
             + ", \"valid-connection-checker-class-name\" => \"%s\" " //
             + "}";
 
-        String dmr = String.format(dmrTemplate, blockingTimeoutWaitMillis, driverName, exceptionSorterClassName,
+        String dmr = String.format(dmrTemplate, xaDataSourceClass, blockingTimeoutWaitMillis, driverName, exceptionSorterClassName,
             idleTimeoutMinutes, jndiName, minPoolSize, maxPoolSize, noRecovery, noTxSeparatePool,
             preparedStatementCacheSize, recoveryPluginClassName, securityDomain, staleConnectionCheckerClassName,
             transactionIsolation, validConnectionCheckerClassName);

--- a/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/ServerInstallUtil.java
+++ b/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/ServerInstallUtil.java
@@ -171,6 +171,8 @@ public class ServerInstallUtil {
     private static final String RHQ_CACHE = "rhqCache";
     private static final String RHQ_MGMT_USER = "rhqadmin";
     private static final String RHQ_MGMT_USER_PASSWORD = "rhq.server.management.password";
+    private static final String XA_DATASOURCE_CLASS_POSTGRES = "org.postgresql.xa.PGXADataSource";
+    private static final String XA_DATASOURCE_CLASS_ORACLE = "oracle.jdbc.xa.client.OracleXADataSource";
 
     /**
      * Configure the logging subsystem.
@@ -603,6 +605,7 @@ public class ServerInstallUtil {
             props.put("DatabaseName", "${rhq.server.database.db-name:rhq}");
 
             xaDsRequest = client.createNewXADatasourceRequest(RHQ_DATASOURCE_NAME_XA, 30000, JDBC_DRIVER_POSTGRES,
+                XA_DATASOURCE_CLASS_POSTGRES,
                 "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter", 15, 5, 50, (Boolean) null,
                 (Boolean) null, 75, (String) null, RHQ_DS_SECURITY_DOMAIN, (String) null, "TRANSACTION_READ_COMMITTED",
                 "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker", props);
@@ -645,6 +648,7 @@ public class ServerInstallUtil {
             props.put("URL", "${rhq.server.database.connection-url:jdbc:oracle:thin:@127.0.0.1:1521:rhq}");
 
             xaDsRequest = client.createNewXADatasourceRequest(RHQ_DATASOURCE_NAME_XA, 30000, JDBC_DRIVER_ORACLE,
+                XA_DATASOURCE_CLASS_ORACLE,
                 "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter", 15, 5, 50, (Boolean) null,
                 Boolean.TRUE, 75, (String) null, RHQ_DS_SECURITY_DOMAIN,
                 "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker",

--- a/modules/enterprise/server/installer/src/test/java/org/rhq/enterprise/server/installer/client/DatasourceJBossASClientTest.java
+++ b/modules/enterprise/server/installer/src/test/java/org/rhq/enterprise/server/installer/client/DatasourceJBossASClientTest.java
@@ -106,6 +106,7 @@ public class DatasourceJBossASClientTest {
         xaDSProps.put("ConnectionProperties", "SetBigStringTryClob=true");
 
         ModelNode request = client.createNewXADatasourceRequest("RHQDS", 30000, "oracle",
+            "oracle.jdbc.xa.client.OracleXADataSource",
             "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter", 15, 2, 5, (Boolean) null,
             Boolean.TRUE, 75, (String) null, "RHQDSSecurityDomain",
             "org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker", "TRANSACTION_READ_COMMITTED",


### PR DESCRIPTION
Installer code fixed to properly fill xa-datasource-class property when
creating RHQDS. Class names for postgres, oracle live as constants in java
class.

This is quite easy fix, the only questionable thing is if we'd like to expose xa-datasource-class name as property in rhq-server.properties or not (I vote for no). This property (or 2, one for pg, one for ora) were exposed in pre-AS7-based RHQ.
