### PR TITLE
[BZ 1080971] JON throws "java.lang.OutOfMemoryError" if drift file sets are big

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/drift/JPADriftServerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/drift/JPADriftServerBean.java
@@ -44,6 +44,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Session;
@@ -548,7 +549,17 @@ public class JPADriftServerBean implements JPADriftServerLocal {
     @Override
     public String getDriftFileBits(String hash) {
         // TODO add security
-        return new String(getDriftFileAsByteArray(hash), Charset.defaultCharset());
+        try {
+            JPADriftFileBits content = (JPADriftFileBits) entityManager.createNamedQuery(
+                JPADriftFileBits.QUERY_FIND_BY_ID).setParameter("hashId", hash).getSingleResult();
+            if (content.getDataSize() == null || content.getDataSize() < 1) {
+                return null;
+            }
+            return IOUtils.toString(content.getBlob().getBinaryStream(), Charset.defaultCharset().name());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
JPADriftServerBean#getDriftFileBits fixed  to return String representation
of bits directly from reading stream. Previous implementation first
allocated byte array from stream and then transformed it into string - this
caused content being twice in memory.
