### PR TITLE
[BZ 1096332] Make sure ResourceContexts are fully inited on the agent

### DIFF
--- a/modules/core/plugin-container/src/main/java/org/rhq/core/pc/PluginContainer.java
+++ b/modules/core/plugin-container/src/main/java/org/rhq/core/pc/PluginContainer.java
@@ -304,6 +304,8 @@ public class PluginContainer {
             driftManager = new DriftManager(configuration, agentServiceStreamRemoter, inventoryManager);
             pingManager = new PingManager(agentServiceStreamRemoter);
 
+            inventoryManager.refreshResourceContainers();
+
             for (AgentServiceLifecycleListener ll : agentServiceListeners) {
                 for (AgentService service : services()) {
                     ll.started(service);

--- a/modules/core/plugin-container/src/main/java/org/rhq/core/pc/inventory/InventoryManager.java
+++ b/modules/core/plugin-container/src/main/java/org/rhq/core/pc/inventory/InventoryManager.java
@@ -323,6 +323,16 @@ public class InventoryManager extends AgentService implements ContainerService, 
         log.info("Inventory Manager initialized.");
     }
 
+    public void refreshResourceContainers() {
+        inventoryLock.writeLock().lock();
+
+        try {
+            activateAndUpgradeResourceRecursively(getPlatform(), false, true);
+        } finally {
+            inventoryLock.writeLock().unlock();
+        }
+    }
+
     /**
      * @see ContainerService#shutdown()
      */
@@ -3599,7 +3609,7 @@ public class InventoryManager extends AgentService implements ContainerService, 
 
             log.info("Starting to activate (and upgrade) resources.");
 
-            activateAndUpgradeResourceRecursively(getPlatform(), syncResult);
+            activateAndUpgradeResourceRecursively(getPlatform(), syncResult, false);
 
             log.info("Inventory activated and upgrade requests gathered in " + (System.currentTimeMillis() - start)
                 + "ms.");
@@ -3614,13 +3624,14 @@ public class InventoryManager extends AgentService implements ContainerService, 
                 t);
 
             //make sure to at least activate the resources
-            activateAndUpgradeResourceRecursively(getPlatform(), false);
+            activateAndUpgradeResourceRecursively(getPlatform(), false, false);
         } finally {
             resourceUpgradeDelegate.disable();
         }
     }
 
-    private void activateAndUpgradeResourceRecursively(Resource resource, boolean doUpgrade) {
+    private void activateAndUpgradeResourceRecursively(Resource resource, boolean doUpgrade,
+        boolean forceReinitialization) {
         ResourceContainer container = initResourceContainer(resource);
 
         boolean activate = true;
@@ -3628,7 +3639,7 @@ public class InventoryManager extends AgentService implements ContainerService, 
         //only do upgrade inside the agent. it does not make sense in embedded mode.
         if (doUpgrade && configuration.isInsideAgent()) {
             try {
-                activate = prepareResourceForActivation(resource, container, false);
+                activate = prepareResourceForActivation(resource, container, forceReinitialization);
                 activate = activate && resourceUpgradeDelegate.processAndQueue(container);
             } catch (Throwable t) {
                 log.error("Exception thrown while upgrading [" + resource + "].", t);
@@ -3638,9 +3649,9 @@ public class InventoryManager extends AgentService implements ContainerService, 
 
         if (activate) {
             try {
-                activateResource(resource, container, false);
+                activateResource(resource, container, forceReinitialization);
                 for (Resource child : getContainerChildren(resource, container)) {
-                    activateAndUpgradeResourceRecursively(child, doUpgrade);
+                    activateAndUpgradeResourceRecursively(child, doUpgrade, forceReinitialization);
                 }
             } catch (InvalidPluginConfigurationException e) {
                 log.debug("Failed to activate resource [" + resource + "] due to invalid plugin configuration.", e);


### PR DESCRIPTION
This fixes the broken "create child" and "content facet" deployment as well as other possibly yet undiscovered problems caused by the incomplete initialization of the resource contexts.

The fix is very simple. So much so that I fear of something more subtle biting us later on.
Please review with sharp eyes, I do think that especially the concurrent access from various scheduled jobs, if possible, could make for wonderful headaches.

Below is the commit message with the full description of the problem:

During InventoryManager initialization we do a lot of work including
activation and initialization of the resource containers and syncing
with the server for the purpose of resource activation and upgrade.

The initialization of the InventoryManager is done early in the
plugin container startup when most of the other services are not yet
available. But because we need a (sort of) functional inventory and
resource components DURING the inventory manager initialization, we
cheat a bit leaving some parts of the ResourceContext non-functional
during InventoryManager initialization. This has been made more serious
by the RFE BZ 991149 (commit 79a09a0a5a5402539f7a54668813f60ba274ce5a)
that made a lot of the initialization code more eager.

This fix is not much more but a band-aid providing a new "recovery
logic" to reinitialize all the resource containers and their resource
contexts once the initialization of all the plugin container services
is finished. This ensures proper initialization of all the parts of
the resource contexts AFTER the plugin containers is fully started up
but doesn't solve the problem of non-functional "parts" of resource
contexts during the resource upgrade phase (which is done during the
start up sequence). Granted this has not been proven to be an issue
yet, because the upgrade logic is usually very simple and doesn't
really need to access the parts of the resource context that are
affected by this (ATM I know of Content and Drift subsystems being
malfunctioning during the resource upgrade phase).

So in another words, this band-aid restores the proper functionality
from the pre-BZ-991149 days but doesn't really try to resolve the
essentially broken nature of our startup logic where we cannot really
guarantee the state of the container services (this is made worse by
the fact that the PluginContainer is a singleton to which any code
can get a reference in any stage of its lifecycle).
