### PR TITLE
BZ 1097921 - first attempt at relaxing agent version check

### DIFF
--- a/modules/core/domain/src/main/java/org/rhq/core/domain/common/ProductInfo.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/common/ProductInfo.java
@@ -38,6 +38,7 @@ public class ProductInfo implements Serializable {
     private String supportEmail;
     private String version;
     private String buildNumber;
+    private String supportedAgentVersions;
     private String helpDocRoot;
     private HashMap<String, String> helpViewContent;
 
@@ -111,6 +112,14 @@ public class ProductInfo implements Serializable {
 
     public void setBuildNumber(String buildNumber) {
         this.buildNumber = buildNumber;
+    }
+
+    public String getSupportedAgentVersions() {
+        return supportedAgentVersions;
+    }
+
+    public void setSupportedAgentVersions(String supportedAgentVersions) {
+        this.supportedAgentVersions = supportedAgentVersions;
     }
 
     public String getHelpDocRoot() {

--- a/modules/enterprise/server/appserver/src/main/scripts/rhq-container.build.xml
+++ b/modules/enterprise/server/appserver/src/main/scripts/rhq-container.build.xml
@@ -1087,10 +1087,6 @@ ${comment}rhq.storage.verify-data-dirs-empty=${rhq.storage.verify-data-dirs-empt
         <zipentry zipfile="${settings.localRepository}/org/rhq/rhq-cassandra-ccm-core/${project.version}/rhq-cassandra-ccm-core-${project.version}.jar"
                   name="cassandra.properties"/>
       </loadproperties>
-        <echo>Putting a developer setting in rhq-server.properties to turn on/off strict agent update version checking</echo>
-        <echo file="${project.build.outputDirectory}/bin/rhq-server.properties" append="true">
-rhq.server.agent-update.nonstrict-version-check=true
-</echo>
 
 <!-- We must use forward slashes when writing paths to a properties files. Properties.load()
      treats the values as Java Strings so backslashes will be parsed as escapes. -->

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/core/AgentManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/core/AgentManagerBean.java
@@ -121,6 +121,7 @@ public class AgentManagerBean implements AgentManagerLocal {
     private static final String RHQ_AGENT_LATEST_VERSION = "rhq-agent.latest.version";
     private static final String RHQ_AGENT_LATEST_BUILD_NUMBER = "rhq-agent.latest.build-number";
     private static final String RHQ_AGENT_LATEST_MD5 = "rhq-agent.latest.md5";
+    private static final String RHQ_AGENT_SUPPORTED_VERSIONS = "rhq-agent.supported.versions";
 
     @ExcludeDefaultInterceptors
     public void createAgent(Agent agent) {
@@ -646,21 +647,25 @@ public class AgentManagerBean implements AgentManagerLocal {
         try {
             Properties properties = getAgentUpdateVersionFileContent();
 
-            // Prime Directive: whatever agent update the server has installed is the one we support,
-            // so both the version AND build number must match.
-            // For developers, however, we want to allow to be less strict - only version needs to match.
-            String supportedAgentVersion = properties.getProperty(RHQ_AGENT_LATEST_VERSION);
-            if (supportedAgentVersion == null) {
+            String supportedAgentVersions = properties.getProperty(RHQ_AGENT_SUPPORTED_VERSIONS); // this is optional
+            String latestAgentVersion = properties.getProperty(RHQ_AGENT_LATEST_VERSION);
+            if (latestAgentVersion == null) {
                 throw new NullPointerException("no agent version in file");
             }
-            ComparableVersion agent = new ComparableVersion(agentVersionInfo.getVersion());
-            ComparableVersion server = new ComparableVersion(supportedAgentVersion);
-            if (Boolean.getBoolean("rhq.server.agent-update.nonstrict-version-check")) {
-                return agent.equals(server);
+
+            boolean isSupported;
+
+            if (supportedAgentVersions == null || supportedAgentVersions.isEmpty()) {
+                // we weren't given a regex of supported versions, make a simple string equality test on latest agent version
+                ComparableVersion agent = new ComparableVersion(agentVersionInfo.getVersion());
+                ComparableVersion server = new ComparableVersion(latestAgentVersion);
+                isSupported = agent.equals(server);
             } else {
-                String supportedAgentBuild = properties.getProperty(RHQ_AGENT_LATEST_BUILD_NUMBER);
-                return agent.equals(server) && agentVersionInfo.getBuild().equals(supportedAgentBuild);
+                // we were given a regex of supported versions, check the agent version to see if it matches the regex
+                isSupported = agentVersionInfo.getVersion().matches(supportedAgentVersions);
             }
+
+            return isSupported;
         } catch (Exception e) {
             LOG.warn("Cannot determine if agent version [" + agentVersionInfo + "] is supported. Cause: " + e);
             return false; // assume we can't talk to it
@@ -681,6 +686,13 @@ public class AgentManagerBean implements AgentManagerLocal {
             CoreServerMBean coreServer = LookupUtil.getCoreServer();
             serverVersionInfo.append(RHQ_SERVER_VERSION + '=').append(coreServer.getVersion()).append('\n');
             serverVersionInfo.append(RHQ_SERVER_BUILD_NUMBER + '=').append(coreServer.getBuildNumber()).append('\n');
+
+            // if there are supported agent versions, get it (this is a regex that is to match agent versions that are supported)
+            String supportedAgentVersions = coreServer.getProductInfo().getSupportedAgentVersions();
+            if (supportedAgentVersions != null && supportedAgentVersions.length() > 0) {
+                serverVersionInfo.append(RHQ_AGENT_SUPPORTED_VERSIONS + '=').append(supportedAgentVersions)
+                    .append('\n');
+            }
 
             // calculate the MD5 of the agent update binary file
             String md5Property = RHQ_AGENT_LATEST_MD5 + '=' + MessageDigestGenerator.getDigestString(binaryFile) + '\n';

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/core/CoreServer.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/core/CoreServer.java
@@ -210,7 +210,6 @@ public class CoreServer implements CoreServerMBean {
                         + PRODUCT_INFO_PROPERTIES_RESOURCE_PATH + "].");
             }
             ProductInfo productInfo = new ProductInfo();
-            // TODO: Using reflection below might be nicer.
             productInfo.setBuildNumber(props.getProperty("buildNumber"));
             productInfo.setFullName(props.getProperty("fullName"));
             productInfo.setHelpDocRoot(props.getProperty("helpDocRoot"));
@@ -221,6 +220,7 @@ public class CoreServer implements CoreServerMBean {
             productInfo.setUrlDomain(props.getProperty("urlDomain"));
             productInfo.setUrl(props.getProperty("url"));
             productInfo.setVersion(props.getProperty("version"));
+            productInfo.setSupportedAgentVersions(props.getProperty("supportedAgentVersions"));
 
             HashMap<String, String> helpViewContent = new HashMap<String, String>();
 

--- a/modules/enterprise/server/jar/src/test/java/org/rhq/enterprise/server/core/AgentSupportedVersionTest.java
+++ b/modules/enterprise/server/jar/src/test/java/org/rhq/enterprise/server/core/AgentSupportedVersionTest.java
@@ -1,0 +1,119 @@
+package org.rhq.enterprise.server.core;
+
+import java.util.Properties;
+import java.util.Random;
+
+import org.testng.annotations.Test;
+
+import org.rhq.core.clientapi.server.core.AgentVersion;
+
+/**
+ * Test that doesn't require any EE infrastructure - just checking to make sure
+ * the agent version check works.
+ *
+ * @author John Mazzitelli
+ */
+@Test
+public class AgentSupportedVersionTest {
+
+    private String agentLatestVersion;
+    private String supportedVersionsRegex;
+
+    // our agent manager to use to run the check - its the real AgentManagerBean that doesn't require any EE infrastructure for this test
+    private AgentManagerBean agentManager = new AgentManagerStub();
+
+    public void testLatestAgentVersionCheck() {
+        AgentVersion agentVersionInfo = setLatestAgentVersionToCheck("1.0.GA", "1.0.GA");
+        assert true == agentManager.isAgentVersionSupported(agentVersionInfo);
+        agentVersionInfo = setLatestAgentVersionToCheck("1.0.GA", "1.0.RC1");
+        assert false == agentManager.isAgentVersionSupported(agentVersionInfo);
+        agentVersionInfo = setLatestAgentVersionToCheck("1.0.GA", "2.0.GA");
+        assert false == agentManager.isAgentVersionSupported(agentVersionInfo);
+    }
+
+    public void testSupportedVersionsCheck() {
+        String regex = "1.0.GA"; // no regex, just a simple string equality test
+        checkOK(regex, "1.0.GA");
+        checkFail(regex, "1.0.RC1");
+        checkFail(regex, "2.0.GA");
+
+        // regex test #1
+        regex = "3.2.0.(GA|CP[12345])";
+        checkOK(regex, "3.2.0.GA");
+        checkOK(regex, "3.2.0.CP1");
+        checkOK(regex, "3.2.0.CP5");
+        checkFail(regex, "3.2.1.GA");
+        checkFail(regex, "3.3.0.CP1");
+
+        // regex test #2
+        regex = "1.[01234].(RC1|RC2|GA)";
+        checkOK(regex, "1.0.RC1");
+        checkOK(regex, "1.1.RC2");
+        checkOK(regex, "1.4.GA");
+        checkFail(regex, "1.5.GA");
+
+        // regex test #3 - combines #1 and #2
+        regex = "(3.2.0.(GA|CP[12345]))|(1.[01234].(RC1|RC2|GA))";
+        checkOK(regex, "3.2.0.GA");
+        checkOK(regex, "3.2.0.CP1");
+        checkOK(regex, "3.2.0.CP5");
+        checkFail(regex, "3.2.1.GA");
+        checkFail(regex, "3.3.0.CP1");
+        checkOK(regex, "1.0.RC1");
+        checkOK(regex, "1.1.RC2");
+        checkOK(regex, "1.4.GA");
+        checkFail(regex, "1.5.GA");
+    }
+
+    private void checkOK(String supportedVersions, String agentVersionToCheck) {
+        check(supportedVersions, agentVersionToCheck, true);
+    }
+
+    private void checkFail(String supportedVersions, String agentVersionToCheck) {
+        check(supportedVersions, agentVersionToCheck, false);
+    }
+
+    private void check(String supportedVersions, String agentVersionToCheck, boolean expectedResult) {
+        AgentVersion agentVersionInfo = setSupportedVersionsToCheck(supportedVersions, agentVersionToCheck);
+        assert expectedResult == agentManager.isAgentVersionSupported(agentVersionInfo) : "supportedVersions="
+            + supportedVersions + "; agentVersionToCheck=" + agentVersionToCheck;
+    }
+
+    private AgentVersion setSupportedVersionsToCheck(String supportedVersionsRegex, String agentVersionToCheck) {
+        this.supportedVersionsRegex = supportedVersionsRegex;
+        this.agentLatestVersion = "0.0.1.irrelevant-version-when-we-have-supported-versions-regex";
+
+        // We don't check build numbers during version check anymore - but just to make sure, always give a different value.
+        // This will show that we don't fail no matter what the build number is.
+        String buildNumber = String.valueOf(new Random().nextInt());
+        return new AgentVersion(agentVersionToCheck, buildNumber);
+    }
+
+    private AgentVersion setLatestAgentVersionToCheck(String agentLatestVersion, String agentVersionToCheck) {
+        this.supportedVersionsRegex = null;
+        this.agentLatestVersion = agentLatestVersion;
+
+        // We don't check build numbers during version check anymore - but just to make sure, always give a different value.
+        // This will show that we don't fail no matter what the build number is.
+        String buildNumber = String.valueOf(new Random().nextInt());
+        return new AgentVersion(agentVersionToCheck, buildNumber);
+    }
+
+    private class AgentManagerStub extends AgentManagerBean {
+        @Override
+        public Properties getAgentUpdateVersionFileContent() {
+            // these are private constants in the subclass, so we don't have access to them - just redefine them here
+            final String RHQ_AGENT_LATEST_VERSION = "rhq-agent.latest.version";
+            final String RHQ_AGENT_SUPPORTED_VERSIONS = "rhq-agent.supported.versions";
+
+            Properties p = new Properties();
+            p.put(RHQ_AGENT_LATEST_VERSION, AgentSupportedVersionTest.this.agentLatestVersion);
+
+            // this is optional, a system does not have to have this set
+            if (AgentSupportedVersionTest.this.supportedVersionsRegex != null) {
+                p.put(RHQ_AGENT_SUPPORTED_VERSIONS, AgentSupportedVersionTest.this.supportedVersionsRegex);
+            }
+            return p;
+        }
+    }
+}


### PR DESCRIPTION
This will allow the server to allow agents to connect to it, even if the agent versions don't match the exact server version (that is, we are now allowing the "prime directive" to be violated).

To supply the server with "supported agent versions", the build infrastructure needs to put "supportedAgentVersions" regex in the Product Info .properties file (this is already being generated, we just need to optionally add supportedAgentVersions - if it doesn't exist, the prime directive remains in force).

Note that no matter what, we no longer look at the build number of the agent to check its acceptability - build numbers are now irrelevant. Only the version string is being checked.
