### PR TITLE
[1094540] Agents get permanently backfilled if backend database goes off...

### DIFF
--- a/modules/core/client-api/src/main/java/org/rhq/core/clientapi/server/core/PingRequest.java
+++ b/modules/core/client-api/src/main/java/org/rhq/core/clientapi/server/core/PingRequest.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 
 /**
  * A simple POJO for requesting actions or data from the ping.
- * 
+ *
  * @author Jay Shaughnessy
  */
 public class PingRequest implements Serializable {
@@ -36,6 +36,7 @@ public class PingRequest implements Serializable {
 
     private boolean replyUpdateAvailability;
     private Long replyServerTimestamp;
+    private boolean replyAgentIsBackfilled;
 
     public PingRequest(String agentName) {
         this(agentName, true, true);
@@ -74,4 +75,13 @@ public class PingRequest implements Serializable {
     public void setReplyServerTimestamp(Long replyServerTimestamp) {
         this.replyServerTimestamp = replyServerTimestamp;
     }
+
+    public boolean isReplyAgentIsBackfilled() {
+        return replyAgentIsBackfilled;
+    }
+
+    public void setReplyAgentIsBackfilled(boolean replyAgentIsBackfilled) {
+        this.replyAgentIsBackfilled = replyAgentIsBackfilled;
+    }
+
 }

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/resource/Agent.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/resource/Agent.java
@@ -150,7 +150,11 @@ import org.rhq.core.domain.cloud.Server;
         + "  WHERE id = :agentId "), //
     @NamedQuery(name = Agent.QUERY_UPDATE_LAST_AVAIL_PING, query = "" //
         + " UPDATE Agent a " //
-        + "    SET lastAvailabilityPing = :now, backFilled = FALSE " //
+        + "    SET lastAvailabilityPing = :now " //
+        + "  WHERE name = :agentName AND backfilled = FALSE "), //
+    @NamedQuery(name = Agent.QUERY_UPDATE_LAST_AVAIL_PING_FORCE, query = "" //
+        + " UPDATE Agent a " //
+        + "    SET lastAvailabilityPing = :now " //
         + "  WHERE name = :agentName ") //
 
 })
@@ -191,6 +195,7 @@ public class Agent implements Serializable {
 
     public static final String QUERY_UPDATE_LAST_AVAIL_REPORT = "Agent.updateLastAvailReport";
     public static final String QUERY_UPDATE_LAST_AVAIL_PING = "Agent.updateLastAvailPing";
+    public static final String QUERY_UPDATE_LAST_AVAIL_PING_FORCE = "Agent.updateLastAvailPingForce";
 
     // this value is set, when authorized user wants to reset the token
     public static final String SECURITY_TOKEN_RESET = "@#$reset$#@";


### PR DESCRIPTION
...line for a moment

Don't unset the backfill flag in the ping logic, just make
sure the agent knows the server thinks its down, and let it
resolve the situation by sending a full avail report, which when
processed will unset the backfill flag.
