### PR TITLE
BZ1094424 - do not reindex tables by default; don't use UNRECOVERABLE

### DIFF
--- a/modules/core/dbutils/src/main/scripts/dbsetup/sysconfig-data.xml
+++ b/modules/core/dbutils/src/main/scripts/dbsetup/sysconfig-data.xml
@@ -96,8 +96,8 @@
               DEFAULT_PROPERTY_VALUE="2678400000" FREAD_ONLY="FALSE"/>
 
         <!-- Whether to reindex the data tables nightly -->
-        <data ID="35" PROPERTY_KEY="DATA_REINDEX_NIGHTLY" PROPERTY_VALUE="true"
-              DEFAULT_PROPERTY_VALUE="true" FREAD_ONLY="FALSE"/>
+        <data ID="35" PROPERTY_KEY="DATA_REINDEX_NIGHTLY" PROPERTY_VALUE="false"
+              DEFAULT_PROPERTY_VALUE="false" FREAD_ONLY="FALSE"/>
 
         <!-- How long to keep alerts around -->
         <data ID="36" PROPERTY_KEY="ALERT_PURGE" PROPERTY_VALUE="2678400000"
@@ -122,7 +122,7 @@
         <!-- How old does availability have to be in order to get purged -->
         <data ID="55" PROPERTY_KEY="AVAILABILITY_PURGE" PROPERTY_VALUE="31536000000"
               DEFAULT_PROPERTY_VALUE="31536000000" FREAD_ONLY="FALSE"/>
-              
+
         <data ID="56" PROPERTY_KEY="RESOURCE_GENERIC_PROPERTIES_UPGRADE" PROPERTY_VALUE="false"
               DEFAULT_PROPERTY_VALUE="false" FREAD_ONLY="FALSE"/>
 

--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/admin/SystemSettingsView.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/admin/SystemSettingsView.java
@@ -448,7 +448,7 @@ public class SystemSettingsView extends EnhancedVLayout implements PropertyValue
                 pd.setDescription(MSG.view_admin_systemSettings_DataReindex_desc());
                 pd.setDisplayName(MSG.view_admin_systemSettings_DataReindex_name());
                 pd.setPropertyGroupDefinition(dataManagerGroup);
-                pd.setDefaultValue("true");
+                pd.setDefaultValue("false");
                 break;
 
             //////////////////////////////////////////////

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/system/SystemManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/system/SystemManagerBean.java
@@ -83,7 +83,7 @@ public class SystemManagerBean implements SystemManagerLocal, SystemManagerRemot
 
     private final String SQL_REINDEX = "REINDEX TABLE {0}";
 
-    private final String SQL_REBUILD = "ALTER INDEX {0} REBUILD UNRECOVERABLE";
+    private final String SQL_REBUILD = "ALTER INDEX {0} REBUILD";
 
     private final String[] TABLES_TO_VACUUM = { "RHQ_RESOURCE", "RHQ_CONFIG", "RHQ_CONFIG_PROPERTY", "RHQ_AGENT" };
 
@@ -371,7 +371,7 @@ public class SystemManagerBean implements SystemManagerLocal, SystemManagerRemot
         case STORAGE_AUTOMATIC_DEPLOYMENT:
         case STORAGE_PASSWORD:
         case STORAGE_USERNAME:
-            return true;        
+            return true;
         default:
             return false;
         }
@@ -806,7 +806,7 @@ public class SystemManagerBean implements SystemManagerLocal, SystemManagerRemot
             return false; // paranoid catch-all
         }
     }
-    
+
     @Override
     public boolean isLoginWithoutRolesEnabled() {
         try {


### PR DESCRIPTION
ALTER INDEX {0} REBUILD UNRECOVERABLE

When being run on Oracle, this prevents inserts while the rebuild takes place,
which may be several minutes. This has caused agents to time out and false
alerts to be generated.

Unrecoverable is not a good idea as it locks the table during the calculation:
https://community.oracle.com/thread/1103546?tstart=0

The default should be false, as well UNRECOVERABLE is not a good idea either on
Oracle because of the locking.
