### PR TITLE
Bug 1102562 - [eap6] Make DomainController's Domain name configurable

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/jboss-as-7/src/main/resources/META-INF/rhq-plugin.xml
@@ -1124,6 +1124,7 @@
                       </c:list-property>
                   </c:group>
       -->
+      <c:simple-property name="name" displayName="Domain Name" required="true" description="Name of the managed domain. This value is same for all HostControllers in domain, but only DomainController resource is allowed to update it."/>
       <c:group name="children:system-property:name+" displayName="System-properties">
         <c:list-property name="*2" displayName="Properties" required="false" readOnly="false">
           <c:map-property name="*:name" displayName="Name" readOnly="true">


### PR DESCRIPTION
Domain Name is now part of resourceConfiguration for DomainController and
HostController resources. Only DC's are allowed to change this configuration
(handled by EAP). As 'Domain Name' is not available (and known) from EAP
admin console, there's a high chance it's unconfigured (having default value
'Unnamed domain'). Plugin tries to be smart and configures this value (if
defaults detected) to "Domain on <DC hostname>:<DC port> - this magic
happens in loadConfiguration()

Although this patch is quite short, I am not sure if HostControllerComponent#loadResourceConfiguration() is the right place to preconfigure. 

I'll merge this unless anyone speaks up within a week.
