### PR TITLE
Always remember the last provided value in case of change operator on a numeric condition.

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/alert/engine/model/NumericDoubleCacheElement.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/alert/engine/model/NumericDoubleCacheElement.java
@@ -83,7 +83,11 @@ public abstract class NumericDoubleCacheElement extends AbstractCacheElement<Dou
         alertConditionValue = providedValue;
 
         if (currentValue == null) {
-            return providedValue != null;
+            //the value is only when we received no values for the metric in question.
+            //hence this is called when the first measurement arrives at which point
+            //we should not alert - the alert condition merely transitions from an uninitialized state
+            //into normal mode of operation.
+            return false;
         } else if (currentValue.isNaN()) {
             return providedValue == null || !providedValue.isNaN();
         } else if (currentValue.isInfinite()) {


### PR DESCRIPTION
This fixes the inability to alert if the definition was created before
first value of the metric used in the condition arrives to the server.

This actually was quite serious, although maybe not that common - if you defined an alert definition for a change of a numeric metric (which is not something users usually do, because such occurrence is usually fairly frequent) and that alert definition was defined before the first value for that metric arrived to the server, the condition would NEVER evaluate to true until the caches for the given agent were reloaded (which could be a long time).

The fix is very simple - just make sure to always update the last known value, but I'm creating a PR for this anyway, because the change is in a highly sensitive area of the code base, so I'd appreciate another pair of eyes on this.
