### PR TITLE
[BZ 1035890] Make REST-originating measurements alertable

### DIFF
--- a/modules/core/dbutils/pom.xml
+++ b/modules/core/dbutils/pom.xml
@@ -17,7 +17,7 @@
     <description>Database schema setup, upgrade and other utilities</description>
 
     <properties>
-        <db.schema.version>2.150</db.schema.version>
+        <db.schema.version>2.151</db.schema.version>
         <rhq.ds.type-mapping>${rhq.test.ds.type-mapping}</rhq.ds.type-mapping>
         <rhq.ds.server-name>${rhq.test.ds.server-name}</rhq.ds.server-name>
         <rhq.ds.db-name>${rhq.test.ds.db-name}</rhq.ds.db-name>

--- a/modules/core/dbutils/src/main/scripts/dbsetup/cluster-schema.xml
+++ b/modules/core/dbutils/src/main/scripts/dbsetup/cluster-schema.xml
@@ -42,6 +42,7 @@
         <column name="SERVER_ID" type="INTEGER" references="RHQ_SERVER" required="false"/>
         <column name="STATUS" type="INTEGER" required="false" default="0" />
         <column name="BACKFILLED" type="BOOLEAN" required="true" />
+        <column name="SYNTHETIC" type="BOOLEAN" required="true" default="false"/>
 
         <index name="RHQ_AGENT_NAME_UNIQUE" unique="true">
             <field ref="NAME"/>

--- a/modules/core/dbutils/src/main/scripts/dbsetup/inventory-schema.xml
+++ b/modules/core/dbutils/src/main/scripts/dbsetup/inventory-schema.xml
@@ -89,6 +89,7 @@
         <column name="LOCATION" required="false" size="100" type="VARCHAR2"/>
         <column name="PARENT_RESOURCE_ID" type="INTEGER" references="RHQ_RESOURCE"/>
         <column name="PRODUCT_VERSION_ID" type="INTEGER" references="RHQ_PRD_VER"/>
+        <column name="SYNTHETIC" type="BOOLEAN" required="true" default="false"/>
 
         <index name="RHQ_RESOURCE_idx_key">
             <field ref="RESOURCE_KEY"/>

--- a/modules/core/dbutils/src/main/scripts/dbupgrade/db-upgrade.xml
+++ b/modules/core/dbutils/src/main/scripts/dbupgrade/db-upgrade.xml
@@ -2384,6 +2384,45 @@
             </schema-directSQL>
           </schemaSpec>
        
+          <schemaSpec version="2.151">
+                <schema-addColumn table="RHQ_AGENT" column="SYNTHETIC" columnType="BOOLEAN"/>
+                <schema-directSQL>
+                    <statement targetDBVendor="postgresql">
+                        UPDATE rhq_agent SET synthetic = false
+                    </statement>
+                    <statement targetDBVendor="oracle">
+                        UPDATE rhq_agent SET synthetic = 0
+                    </statement>
+                </schema-directSQL>
+                <schema-directSQL>
+                    <statement targetDBVendor="postgresql">
+                        UPDATE rhq_agent SET synthetic = true WHERE name LIKE 'dummy-agent:name%'
+                    </statement>
+                    <statement targetDBVendor="oracle">
+                        UPDATE rhq_agent SET synthetic = 1 WHERE name LIKE 'dummy-agent:name%'
+                    </statement>
+                </schema-directSQL>
+                <schema-alterColumn table="RHQ_AGENT" column="SYNTHETIC" nullable="false"/>
+
+                <schema-addColumn table="RHQ_RESOURCE" column="SYNTHETIC" columnType="BOOLEAN"/>
+                <schema-directSQL>
+                    <statement targetDBVendor="postgresql">
+                        UPDATE rhq_resource SET synthetic = false
+                    </statement>
+                    <statement targetDBVendor="oracle">
+                        UPDATE rhq_resource SET synthetic = 0
+                    </statement>
+                </schema-directSQL>
+                <schema-directSQL>
+                    <statement targetDBVendor="postgresql">
+                        UPDATE rhq_resource SET synthetic = true WHERE resource_key LIKE 'res:%' AND description LIKE '%. Created via REST-api'
+                    </statement>
+                    <statement targetDBVendor="oracle">
+                        UPDATE rhq_resource SET synthetic = 1 WHERE resource_key LIKE 'res:%' AND description LIKE '%. Created via REST-api'
+                    </statement>
+                </schema-directSQL>
+                <schema-alterColumn table="RHQ_RESOURCE" column="SYNTHETIC" nullable="false"/>
+            </schemaSpec>
         </dbupgrade>
     </target>
 </project>

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/discovery/PlatformSyncInfo.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/discovery/PlatformSyncInfo.java
@@ -76,7 +76,7 @@ public class PlatformSyncInfo implements Serializable {
     public static PlatformSyncInfo buildPlatformSyncInfo(Resource platform) {
         Set<Integer> toplevelServerIds = new HashSet<Integer>();
         for (Resource r : platform.getChildResources()) {
-            if (r.getResourceType().getCategory().equals(ResourceCategory.SERVER)) {
+            if (r.getResourceType().getCategory().equals(ResourceCategory.SERVER) && !r.isSynthetic()) {
                 toplevelServerIds.add(r.getId());
             }
         }

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/resource/Resource.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/resource/Resource.java
@@ -981,7 +981,7 @@ public class Resource implements Comparable<Resource>, Serializable {
 
     private static final int UUID_LENGTH = 36;
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     public static final String ANCESTRY_ENTRY_DELIM = "_:_"; // delimiter separating entry fields
     public static final String ANCESTRY_DELIM = "_::_"; // delimiter seperating ancestry entries
@@ -1172,6 +1172,9 @@ public class Resource implements Comparable<Resource>, Serializable {
     @OneToMany(mappedBy = "resource", fetch = FetchType.LAZY, cascade = { CascadeType.ALL })
     @org.hibernate.annotations.Cascade(org.hibernate.annotations.CascadeType.DELETE_ORPHAN)
     private Set<DriftDefinition> driftDefinitions = null;
+
+    @Column(name = "SYNTHETIC", nullable = false)
+    private boolean synthetic;
 
     @Transient
     private final boolean customChildResourcesCollection;
@@ -1967,6 +1970,25 @@ public class Resource implements Comparable<Resource>, Serializable {
      */
     public boolean hasCustomChildResourcesCollection() {
         return customChildResourcesCollection;
+    }
+
+    /**
+     * Synthetic resources are those that were not discovered on or manually added to agents.
+     * Also resources added to synthetic agents are all by definition synthetic.
+     * <p/>
+     * For the server-side, a synthetic resource behaves just like any other normal resource
+     * (only any updates or measurements to it can only come through REST iface). On the agents
+     * synthetic resources are completely ignored.
+     */
+    public boolean isSynthetic() {
+        return synthetic;
+    }
+
+    /**
+     * @see #isSynthetic()
+     */
+    public void setSynthetic(boolean synthetic) {
+        this.synthetic = synthetic;
     }
 
     // NOTE: It's vital that compareTo() is consistent with equals(), otherwise TreeSets containing Resources, or

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/resource/composite/ResourceIdWithAgentComposite.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/resource/composite/ResourceIdWithAgentComposite.java
@@ -23,18 +23,20 @@ import java.io.Serializable;
 import org.rhq.core.domain.resource.Agent;
 
 /**
- * (resourceId, agent) tuple
+ * (resourceId, synthetic, agent) tuple. Synthetic is true if the resource in question is synthetic.
  * 
  * @author Jirka Kremser
  */
 public class ResourceIdWithAgentComposite implements Serializable {
 
-    private static final long serialVersionUID = 42L;
+    private static final long serialVersionUID = 43L;
     private final int resourceId;
     private final Agent agent;
+    private final boolean synthetic;
 
-    public ResourceIdWithAgentComposite(int resourceId, Agent agent) {
+    public ResourceIdWithAgentComposite(int resourceId, boolean synthetic, Agent agent) {
         this.resourceId = resourceId;
+        this.synthetic = synthetic;
         this.agent = agent;
     }
 
@@ -44,5 +46,9 @@ public class ResourceIdWithAgentComposite implements Serializable {
 
     public Agent getAgent() {
         return agent;
+    }
+
+    public boolean isSynthetic() {
+        return synthetic;
     }
 }

--- a/modules/core/domain/src/test/java/org/rhq/core/domain/discovery/PlatformSyncInfoTest.java
+++ b/modules/core/domain/src/test/java/org/rhq/core/domain/discovery/PlatformSyncInfoTest.java
@@ -1,0 +1,38 @@
+package org.rhq.core.domain.discovery;
+
+import org.testng.annotations.Test;
+
+import org.rhq.core.domain.resource.Resource;
+import org.rhq.core.domain.resource.ResourceCategory;
+import org.rhq.core.domain.resource.ResourceType;
+
+/**
+ * @author Lukas Krejci
+ * @since 4.12
+ */
+@Test
+public class PlatformSyncInfoTest {
+
+    public void testSyntheticResourcesIgnoredInBuilder() {
+        ResourceType rt = new ResourceType("fake", "fake", ResourceCategory.SERVER, null);
+
+        Resource platform = new Resource();
+        platform.setId(1);
+        platform.setResourceType(rt);
+
+        Resource regularChild = new Resource();
+        regularChild.setId(2);
+        platform.addChildResource(regularChild);
+        regularChild.setResourceType(rt);
+
+        Resource syntheticChild = new Resource();
+        syntheticChild.setId(2);
+        syntheticChild.setSynthetic(true);
+        platform.addChildResource(syntheticChild);
+        syntheticChild.setResourceType(rt);
+
+        PlatformSyncInfo syncInfo = PlatformSyncInfo.buildPlatformSyncInfo(platform);
+
+        assert syncInfo.getTopLevelServerIds().size() == 1 && syncInfo.getTopLevelServerIds().iterator().next() == 2;
+    }
+}

--- a/modules/core/plugin-container/src/main/java/org/rhq/core/pc/measurement/MeasurementManager.java
+++ b/modules/core/plugin-container/src/main/java/org/rhq/core/pc/measurement/MeasurementManager.java
@@ -454,7 +454,7 @@ public class MeasurementManager extends AgentService implements MeasurementAgent
         MeasurementFacet measurementFacet;
         ResourceContainer resourceContainer = inventoryManager.getResourceContainer(resourceId);
         if (resourceContainer == null) {
-            LOG.warn("Can not get resource container for resource with id " + resourceId);
+            LOG.warn("Cannot get resource container for resource with id " + resourceId);
             return Collections.emptySet();
         }
         Resource resource = resourceContainer.getResource();

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossLocal.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossLocal.java
@@ -40,6 +40,7 @@ import org.rhq.core.domain.discovery.MergeInventoryReportResults;
 import org.rhq.core.domain.discovery.MergeResourceResponse;
 import org.rhq.core.domain.discovery.PlatformSyncInfo;
 import org.rhq.core.domain.discovery.ResourceSyncInfo;
+import org.rhq.core.domain.measurement.ResourceMeasurementScheduleRequest;
 import org.rhq.core.domain.resource.Agent;
 import org.rhq.core.domain.resource.InventoryStatus;
 import org.rhq.core.domain.resource.Resource;
@@ -91,7 +92,7 @@ public interface DiscoveryBossLocal extends DiscoveryBossRemote {
     PlatformSyncInfo getPlatformSyncInfo(Agent knownAgent);
 
     /**
-     * @param resourceid the root resourceId on which we want to sync
+     * @param resourceId the root resourceId on which we want to sync
      * @return null if resource not found, otherwise the entire tree rooted at the specified resource, as an
      * unordered collection.  Although not strictly a Set (to save on computation) this collection should not
      * contain duplicates.
@@ -233,4 +234,17 @@ public interface DiscoveryBossLocal extends DiscoveryBossRemote {
     Set<ResourceUpgradeResponse> upgradeResources(Set<ResourceUpgradeRequest> upgradeRequests);
 
     void updateAgentInventoryStatus(String platformsList, String serversList);
+
+    /**
+     * Gives the server a chance to apply any necessary post-processing that's needed for newly committed resources
+     * that have been successfully synchronized on the agent.
+     *
+     * @param  resourceIds a collection of{@link Resource} ids that have been newly committed and successfully
+     *                     synchronized on the agent
+     *
+     * @return the current list of measurement schedules that should be installed agent side for each resource contained
+     *         within the passed set
+     */
+    Set<ResourceMeasurementScheduleRequest> postProcessNewlyCommittedResources(Set<Integer> resourceIds);
+
 }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/drift/JPADriftServerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/drift/JPADriftServerBean.java
@@ -447,6 +447,11 @@ public class JPADriftServerBean implements JPADriftServerLocal {
     public void ackChangeSetInNewTransaction(Subject subject, final int resourceId, final Headers headers,
         final List<JPADriftFile> driftFilesToRequest) throws Exception {
 
+        Resource resource = entityManager.find(Resource.class, resourceId);
+        if (resource.isSynthetic()) {
+            return;
+        }
+
         try {
             AgentClient agentClient = agentManager.getAgentClient(subjectManager.getOverlord(), resourceId);
             DriftAgentService service = agentClient.getDriftAgentService();

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/AgentRequestFullAvailabilityJob.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/AgentRequestFullAvailabilityJob.java
@@ -102,6 +102,10 @@ public class AgentRequestFullAvailabilityJob implements Job {
         // it; if it's down we'll get a full report when it comes up.
         AgentManagerLocal agentManager = LookupUtil.getAgentManager();
         for (Agent agent : internalizeJobValues((String) jobDataMap.get(AGENTS))) {
+            if (agent.isSynthetic()) {
+                continue;
+            }
+
             try {
                 AgentClient agentClient = agentManager.getAgentClient(agent);
                 agentClient.getDiscoveryAgentService().requestFullAvailabilityReport();

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/ResourceFactoryManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/ResourceFactoryManagerBean.java
@@ -695,9 +695,13 @@ public class ResourceFactoryManagerBean implements ResourceFactoryManagerLocal, 
         DeleteResourceRequest request = new DeleteResourceRequest(persistedHistory.getId(), resourceId);
 
         try {
-            AgentClient agentClient = agentManager.getAgentClient(agent);
-            ResourceFactoryAgentService resourceFactoryAgentService = agentClient.getResourceFactoryAgentService();
-            resourceFactoryAgentService.deleteResource(request);
+            if (resource.isSynthetic()) {
+                resourceFactoryManager.completeDeleteResourceRequest(new DeleteResourceResponse(persistedHistory.getId(), DeleteResourceStatus.SUCCESS, null));
+            } else {
+                AgentClient agentClient = agentManager.getAgentClient(agent);
+                ResourceFactoryAgentService resourceFactoryAgentService = agentClient.getResourceFactoryAgentService();
+                resourceFactoryAgentService.deleteResource(request);
+            }
 
             return persistedHistory;
         } catch (CannotConnectException e) {

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/MetricHandlerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/MetricHandlerBean.java
@@ -76,6 +76,7 @@ import org.rhq.core.domain.measurement.MeasurementDataNumeric;
 import org.rhq.core.domain.measurement.MeasurementDataPK;
 import org.rhq.core.domain.measurement.MeasurementDataTrait;
 import org.rhq.core.domain.measurement.MeasurementDefinition;
+import org.rhq.core.domain.measurement.MeasurementReport;
 import org.rhq.core.domain.measurement.MeasurementSchedule;
 import org.rhq.core.domain.measurement.MeasurementScheduleRequest;
 import org.rhq.core.domain.measurement.calltime.CallTimeData;
@@ -840,7 +841,7 @@ public class MetricHandlerBean  extends AbstractRestBean  {
         }
         Set<CallTimeData> data = new HashSet<CallTimeData>();
         data.add(ctd);
-        calltimeDataManager.addCallTimeData(data);
+        dataManager.mergeMeasurementReport(getCalltimeMeasurementReport(data));
         UriBuilder uriBuilder = uriInfo.getBaseUriBuilder();
         uriBuilder.path("/metric/data/{scheduleId}/callTime");
         uriBuilder.queryParam("startTime",startTime);
@@ -875,7 +876,7 @@ public class MetricHandlerBean  extends AbstractRestBean  {
         Set<MeasurementDataNumeric> data = new HashSet<MeasurementDataNumeric>(1);
         data.add(new MeasurementDataNumeric(timestamp,scheduleId,value.getValue()));
 
-        dataManager.addNumericData(data);
+        dataManager.mergeMeasurementReport(getNumericMeasurementReport(data));
 
         UriBuilder uriBuilder = uriInfo.getBaseUriBuilder();
         uriBuilder.path("/metric/data/{scheduleId}/raw");
@@ -908,7 +909,7 @@ public class MetricHandlerBean  extends AbstractRestBean  {
         MeasurementDataPK pk = new MeasurementDataPK(timestamp,scheduleId);
         traits.add(new MeasurementDataTrait(pk,value.getValue()));
 
-        dataManager.addTraitData(traits);
+        dataManager.mergeMeasurementReport(getTraitMeasurementReport(traits));
 
         return Response.ok().build();
     }
@@ -948,7 +949,7 @@ public class MetricHandlerBean  extends AbstractRestBean  {
             data.add(new MeasurementDataNumeric(point.getTimeStamp(), point.getScheduleId(),point.getValue()));
         }
 
-        dataManager.addNumericData(data);
+        dataManager.mergeMeasurementReport(getNumericMeasurementReport(data));
 
         return Response.noContent().type(mediaType).build();
 
@@ -972,7 +973,7 @@ public class MetricHandlerBean  extends AbstractRestBean  {
             // TODO signal bad items to the caller?
         }
 
-        dataManager.addNumericData(data);
+        dataManager.mergeMeasurementReport(getNumericMeasurementReport(data));
 
         return Response.noContent().type(mediaType).build();
     }
@@ -1216,5 +1217,23 @@ public class MetricHandlerBean  extends AbstractRestBean  {
             pw.flush();
             pw.close();
         }
+    }
+
+    private MeasurementReport getNumericMeasurementReport(Set<MeasurementDataNumeric> numericData) {
+        MeasurementReport ret = new MeasurementReport();
+        ret.getNumericData().addAll(numericData);
+        return ret;
+    }
+
+    private MeasurementReport getTraitMeasurementReport(Set<MeasurementDataTrait> traitData) {
+        MeasurementReport ret = new MeasurementReport();
+        ret.getTraitData().addAll(traitData);
+        return ret;
+    }
+
+    private MeasurementReport getCalltimeMeasurementReport(Set<CallTimeData> callTimeData) {
+        MeasurementReport ret = new MeasurementReport();
+        ret.getCallTimeData().addAll(callTimeData);
+        return ret;
     }
 }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/domain/CreateCBResourceRequest.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/domain/CreateCBResourceRequest.java
@@ -53,4 +53,19 @@ public class CreateCBResourceRequest extends ResourceWithType {
         this.resourceConfig = resourceConfig;
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CreateCBResourceRequest[");
+        sb.append("resourceName='").append(resourceName).append('\'');
+        sb.append(", resourceId=").append(resourceId);
+        sb.append(", typeName='").append(typeName).append('\'');
+        sb.append(", typeId=").append(typeId);
+        sb.append(", pluginName='").append(pluginName).append('\'');
+        sb.append(", parentId=").append(parentId);
+        sb.append(", ancestry='").append(getAncestry()).append('\'');
+        sb.append(", pluginConfig=").append(pluginConfig);
+        sb.append(", resourceConfig=").append(resourceConfig);
+        sb.append(']');
+        return sb.toString();
+    }
 }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/support/SupportManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/support/SupportManagerBean.java
@@ -31,12 +31,14 @@ import org.rhq.core.clientapi.agent.support.SupportAgentService;
 import org.rhq.core.domain.auth.Subject;
 import org.rhq.core.domain.authz.Permission;
 import org.rhq.core.domain.cloud.Server;
+import org.rhq.core.domain.resource.Resource;
 import org.rhq.core.util.stream.StreamUtil;
 import org.rhq.enterprise.server.agentclient.AgentClient;
 import org.rhq.enterprise.server.auth.SubjectManagerLocal;
 import org.rhq.enterprise.server.authz.RequiredPermission;
 import org.rhq.enterprise.server.cloud.instance.ServerManagerLocal;
 import org.rhq.enterprise.server.core.AgentManagerLocal;
+import org.rhq.enterprise.server.resource.ResourceManagerLocal;
 import org.rhq.enterprise.server.util.LookupUtil;
 
 /**
@@ -64,9 +66,17 @@ public class SupportManagerBean implements SupportManagerLocal, SupportManagerRe
     @EJB
     private SubjectManagerLocal subjectManager;
 
+    @EJB
+    private ResourceManagerLocal resourceManager;
+
     @RequiredPermission(Permission.MANAGE_INVENTORY)
     public InputStream getSnapshotReportStream(Subject subject, int resourceId, String name, String description)
         throws Exception {
+
+        Resource resource = resourceManager.getResourceById(subject, resourceId);
+        if (resource.isSynthetic()) {
+            throw new IllegalArgumentException("Support facet not supported on synthetic resources.");
+        }
 
         AgentClient agentClient = this.agentManager.getAgentClient(subjectManager.getOverlord(), resourceId);
         SupportAgentService supportService = agentClient.getSupportAgentService();


### PR DESCRIPTION
This required quite a bit of changes across the codebase to correctly
support. While the metric-push in the REST didn't need any changes,
there had to be quite a number of changes in the way resources are
created over REST.

The previous implementation was a bit naive in that it merely tried to
push stuff into database without invoking the usual agent-server
work-flows that made sure that everything was set up, including
alerting.

This commit does several things:
- It invokes the same workflow during resource creation over REST as
  would have been using the normal agent-server communication.
- It formalizes the fact that the agents and resources created over
  REST can be synthetic by introducing a DB column in the appropriate
  tables. There are simple rules governing the synthetic resources:
  a) a synthetic parent can only have synthetic children
  b) the above rule applies even in cases where the resource is
  otherwise creatable.
  This has the following consequences: one can create ANY type of
  resource (even content-backed - for which the content is merely ignored)
  on an synthetic agent, but the resource is always synthetic. A "real"
  resource can have synthetic children but not otherwise. Normally
  creatable resources can still be created over REST under
  "real" parents.
- HA servers periodically scan the synthetic agents and claim
  ownership of them if the last owning server didn't check in in due
  time. This is to support alerting that assumes that each agent is
  owned by exactly one server at any given time.
- All places in the server.jar that reach out to agents to do some
  work have been augmented to take the synthetic resources into
  consideration somehow (usually just leaving them out of the
  "picture", because agents can't do anything about these resources).
- Agents aren't even aware of these synthetic resources because they are
  not synced. It would not make sense for an agent to do anything about
  a synthetic resource because such resource doesn't "physically" exist on
  any agent. It is only backed by the data pushed through REST.
