### PR TITLE
Add support for IncludeOptional directive added in httpd 2.3.6.

### DIFF
--- a/modules/plugins/apache/src/main/java/org/rhq/plugins/apache/augeas/AugeasConfigurationApache.java
+++ b/modules/plugins/apache/src/main/java/org/rhq/plugins/apache/augeas/AugeasConfigurationApache.java
@@ -53,8 +53,7 @@ import org.rhq.rhqtransform.impl.PluginDescriptorBasedAugeasConfiguration;
  */
 public class AugeasConfigurationApache extends PluginDescriptorBasedAugeasConfiguration {
 
-    public static final String INCLUDE_DIRECTIVE = "Include";
-    private static final String INCLUDE_FILES_PATTERN = "^[\t ]*Include[\t ]+(.*)$";
+    private static final String INCLUDE_FILES_PATTERN = "^[\t ]*Include(?:Optional)?[\t ]+(.*)$";
     private static final String SERVER_ROOT_PATTERN = "^[\t ]*ServerRoot[\t ]+[\"]?([^\"\n]*)[\"]?$";
 
     private final Pattern includePattern = Pattern.compile(INCLUDE_FILES_PATTERN);

--- a/modules/plugins/apache/src/main/java/org/rhq/plugins/apache/augeas/AugeasTreeBuilderApache.java
+++ b/modules/plugins/apache/src/main/java/org/rhq/plugins/apache/augeas/AugeasTreeBuilderApache.java
@@ -114,12 +114,13 @@ public class AugeasTreeBuilderApache implements AugeasTreeBuilder {
             parentNode.addIncludeNodes(includeNode, createdNodes);
 
         for (AugeasNode node : createdNodes) {
-            if (canContainNestedNodes(node.getLabel())) {
+            String label = node.getLabel();
+            if (canContainNestedNodes(label)) {
                 String labelName =
-                    node.getLabel() + ((node.getSeq() != 0) ? "[" + String.valueOf(node.getSeq()) + "]" : "");
+                    label + ((node.getSeq() != 0) ? "[" + String.valueOf(node.getSeq()) + "]" : "");
                 updateIncludes((ApacheAugeasNode) node, tree, fileName + File.separator + labelName, null);
             }
-            if (node.getLabel().equals("Include")) {
+            if (label.equals("Include") || label.equals("IncludeOptional")) {
                 String val = ag.get(node.getFullPath() + File.separator + "param");
                 if (includes.containsKey(val)) {
                     //include directive contains globNames

--- a/modules/plugins/apache/src/main/java/org/rhq/plugins/apache/parser/ApacheParserImpl.java
+++ b/modules/plugins/apache/src/main/java/org/rhq/plugins/apache/parser/ApacheParserImpl.java
@@ -33,6 +33,7 @@ import org.rhq.plugins.apache.util.RuntimeApacheConfiguration;
 public class ApacheParserImpl implements ApacheParser {
 
     private final static String INCLUDE_DIRECTIVE = "Include";
+    private final static String INCLUDEOPTIONAL_DIRECTIVE = "IncludeOptional";
     private static final String SERVER_ROOT_DIRECTIVE = "ServerRoot";
     private final ApacheDirectiveTree tree;
     private ApacheDirectiveStack stack;
@@ -60,20 +61,22 @@ public class ApacheParserImpl implements ApacheParser {
             return;
         }
 
-        if (directive.getName().equals(INCLUDE_DIRECTIVE)) {
+        String directiveName = directive.getName();
+
+        if (directiveName.equals(INCLUDE_DIRECTIVE) || directiveName.equals(INCLUDEOPTIONAL_DIRECTIVE)) {
             List<File> files = getIncludeFiles(directive.getValuesAsString());
             for (File fl : files) {
                 if (fl.exists() && fl.isFile()) {
                     ApacheConfigReader.searchFile(fl.getAbsolutePath(), this);
                 }
             }
-        } else if (directive.getName().equals(SERVER_ROOT_DIRECTIVE)) {
+        } else if (directiveName.equals(SERVER_ROOT_DIRECTIVE)) {
             this.serverRootPath = AugeasNodeValueUtil.unescape(directive.getValuesAsString());
         }
 
         if (nodeInspector != null) {
             //let the inspector process this directive in case it sees something of interest
-            nodeInspector.inspect(directive.getName(), directive.getValues(), directive.getValuesAsString());
+            nodeInspector.inspect(directiveName, directive.getValues(), directive.getValuesAsString());
         }
 
         directive.setParentNode(stack.getLastDirective());


### PR DESCRIPTION
This seems to be used by default on newer systems (at least Fedora 20
has it) causing the apache plugin to not discover large parts of
httpd inventory subtree.

I'm pushing this as a PR to discuss whether we even want this in. IMHO, it is fairly low-risk small change but we've had our issues with apache plugin... ;)
