### PR TITLE
[BZ 1115415] Make resources in the discovery q possible to manually add

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossBean.java
@@ -666,19 +666,27 @@ public class DiscoveryBossBean implements DiscoveryBossLocal, DiscoveryBossRemot
                 + resource.getResourceType());
         }
 
+        Subject creator = this.subjectManager.getSubjectById(creatorSubjectId);
+        try {
+            creator = this.subjectManager.loginUnauthenticated(creator.getName());
+        } catch (LoginException e) {
+            throw new IllegalStateException(
+                "Unable to temporarily login to provided resource creator user for resource creation", e);
+        }
+
         Resource existingResource = findExistingResource(resource, null);
         if (existingResource != null) {
+            if (existingResource.getInventoryStatus() != InventoryStatus.COMMITTED) {
+                existingResource.setInventoryStatus(InventoryStatus.COMMITTED);
+                existingResource.setModifiedBy(creator.getName());
+                existingResource.setItime(System.currentTimeMillis());
+                existingResource.setMtime(existingResource.getItime());
+                existingResource.setPluginConfiguration(resource.getPluginConfiguration());
+            }
+
             mergeResourceResponse = new MergeResourceResponse(existingResource.getId(), existingResource.getMtime(),
                 true);
         } else {
-            Subject creator = this.subjectManager.getSubjectById(creatorSubjectId);
-            try {
-                creator = this.subjectManager.loginUnauthenticated(creator.getName());
-            } catch (LoginException e) {
-                throw new IllegalStateException(
-                    "Unable to temporarily login to provided resource creator user for resource creation", e);
-            }
-
             Resource parentResource = this.resourceManager.getResourceById(creator, resource.getParentResource()
                 .getId());
             resource.setAgent(parentResource.getAgent());


### PR DESCRIPTION
During resource add we ignored resources already existing in the inventory. 
Resources in the discovery queue ARE present in the inventory with the status
set to NEW.

---

This behavior was present in the codebase since the dawn of time so I am
a little bit nervous about changing it. Not sure about the (c|m|i)time values
as well as whether to create history entry for such resources, etc.

Also I still need to investigate how this behaves for the ephemeral 
uninventoried resources before they asyncly disappear from the database.

What are your thoughts?
