### PR TITLE
Bug 1053483 - RHQ Admin UI references 'Cassandra' rather than storage node

### DIFF
--- a/modules/plugins/rhq-storage/src/main/java/org/rhq/plugins/storage/JvmServerDiscoveryComponent.java
+++ b/modules/plugins/rhq-storage/src/main/java/org/rhq/plugins/storage/JvmServerDiscoveryComponent.java
@@ -1,0 +1,68 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2014 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation, and/or the GNU Lesser
+ * General Public License, version 2.1, also as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.rhq.plugins.storage;
+
+import java.util.Set;
+
+import org.rhq.core.domain.resource.ResourceUpgradeReport;
+import org.rhq.core.pluginapi.inventory.DiscoveredResourceDetails;
+import org.rhq.core.pluginapi.inventory.ResourceComponent;
+import org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext;
+import org.rhq.core.pluginapi.upgrade.ResourceUpgradeContext;
+import org.rhq.core.pluginapi.upgrade.ResourceUpgradeFacet;
+import org.rhq.plugins.jmx.EmbeddedJMXServerDiscoveryComponent;
+import org.rhq.plugins.jmx.JMXComponent;
+
+/**
+ * 
+ * @author lzoubek@redhat.com
+ *
+ */
+public class JvmServerDiscoveryComponent extends EmbeddedJMXServerDiscoveryComponent implements
+    ResourceUpgradeFacet<ResourceComponent<?>> {
+
+    @Override
+    public Set<DiscoveredResourceDetails> discoverResources(ResourceDiscoveryContext<JMXComponent<?>> context)
+        throws Exception {
+        Set<DiscoveredResourceDetails> details = super.discoverResources(context);
+        if (!details.isEmpty()) {
+            // singleton resource, so we can safely update first item
+            DiscoveredResourceDetails res = details.iterator().next();
+            res.setResourceName("JVM");
+        }
+        return details;
+    }
+
+    @Override
+    public ResourceUpgradeReport upgrade(ResourceUpgradeContext<ResourceComponent<?>> inventoriedResource) {
+        ResourceUpgradeReport report = new ResourceUpgradeReport();
+        if ("Cassandra Server JVM".equals(inventoriedResource.getName())) {
+            report.setNewName("JVM");
+            report.setNewDescription("The JVM of the Storage node");
+            report.setForceGenericPropertyUpgrade(true);
+            return report;
+        }
+        return null;
+    }
+
+}

--- a/modules/plugins/rhq-storage/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/rhq-storage/src/main/resources/META-INF/rhq-plugin.xml
@@ -221,9 +221,9 @@
 
     <server name="Cassandra Server JVM"
             sourcePlugin="JMX" sourceType="JMX Server"
-            discovery="org.rhq.plugins.jmx.EmbeddedJMXServerDiscoveryComponent"
+            discovery="JvmServerDiscoveryComponent"
             class="org.rhq.plugins.jmx.EmbeddedJMXServerComponent"
-            description="The JVM of the Cassandra node"
+            description="The JVM of the Storage node"
             singleton="true">
 
       <plugin-configuration>


### PR DESCRIPTION
I am opening up this as a pull request to get answer for a simple question:

"How to rename a resource type?"

I can see 2 ways of doing this.
1. rename resource type. This would cause the original "Cassandra Server JVM" resources to disappear and new "JVM" would be discovered.
   - drawback - metric history is lost
2. keep resource type name and update discovery/upgrade code - this approach keeps all metrics and can rename existing resources and give proper name ("JVM") to new resources. 
   - drawback - resource type is still called "Cassandra JVM Server"
3. may be to add support for resource type name change to plugin descriptor (ie. via new attribute oldName), then we can pair old and new resource type and we don't remove the old type and insert new one.

I've chosen 2. because I think it is important to keep metrics especially for storage nodes.
