### PR TITLE
BZ-1127928: Setting appropriate defaults for new properties trustStrateg...

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/ServerPluginConfiguration.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/ServerPluginConfiguration.java
@@ -227,11 +227,11 @@ public class ServerPluginConfiguration {
     }
 
     public TrustStrategy getTrustStrategy() {
-        return TrustStrategy.findByName(pluginConfig.getSimpleValue(Property.TRUST_STRATEGY));
+        return TrustStrategy.findByName(pluginConfig.getSimpleValue(Property.TRUST_STRATEGY, TrustStrategy.STANDARD.name));
     }
 
     public HostnameVerification getHostnameVerification() {
-        return HostnameVerification.findByName(pluginConfig.getSimpleValue(Property.HOSTNAME_VERIFICATION));
+        return HostnameVerification.findByName(pluginConfig.getSimpleValue(Property.HOSTNAME_VERIFICATION, HostnameVerification.STRICT.name));
     }
 
     public String getTruststoreType() {


### PR DESCRIPTION
...y and hostnameVerification introduced in BZ-1062552.

These defaults are used when the property is loaded from the resource's
plug-in configuration. This is necessary to handle situations in where a
resource was already in inventory when the new plug-in is installed.
