### PR TITLE
Bug 1096332 - All content-related workflows broken on Agent

### DIFF
--- a/modules/core/plugin-container/pom.xml
+++ b/modules/core/plugin-container/pom.xml
@@ -331,6 +331,12 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <skipTests>true</skipTests>
+            <properties>
+              <property>
+                <name>listener</name>
+                <value>org.rhq.test.testng.StdoutReporter</value>
+              </property>
+            </properties>
         </configuration>
         <executions>
             <execution>

--- a/modules/core/plugin-container/src/main/java/org/rhq/core/pc/PluginContainer.java
+++ b/modules/core/plugin-container/src/main/java/org/rhq/core/pc/PluginContainer.java
@@ -288,13 +288,15 @@ public class PluginContainer {
 
             PluginLifecycleListenerManager pluginLifecycle = new PluginLifecycleListenerManagerImpl();
             pluginManager = new PluginManager(configuration, pluginLifecycle);
-            eventManager = new EventManager(configuration);
-            operationManager = new OperationManager(configuration, agentServiceStreamRemoter);
-            inventoryManager = new InventoryManager(configuration, agentServiceStreamRemoter, pluginManager,
-                eventManager, operationManager);
+            inventoryManager = new InventoryManager(configuration, agentServiceStreamRemoter, pluginManager);
             inventoryManager.initialize();
+            eventManager = inventoryManager.getEventManager();
+            eventManager.initialize();
+            operationManager = inventoryManager.getOperationManager();
             measurementManager = inventoryManager.getMeasurementManager();
+            measurementManager.initialize();
             contentManager = inventoryManager.getContentManager();
+            contentManager.initialize();
             pluginComponentFactory = inventoryManager.getPluginComponentFactory();
             ComponentService componentService = new ComponentServiceImpl(pluginManager);
             ConfigManagementFactory factory = new ConfigManagementFactoryImpl(componentService);

--- a/modules/core/plugin-container/src/test/java/org/rhq/core/pc/bundle/BundleManagerTest.java
+++ b/modules/core/plugin-container/src/test/java/org/rhq/core/pc/bundle/BundleManagerTest.java
@@ -62,11 +62,9 @@ import org.rhq.core.domain.resource.ResourceCategory;
 import org.rhq.core.domain.resource.ResourceType;
 import org.rhq.core.pc.PluginContainerConfiguration;
 import org.rhq.core.pc.ServerServices;
-import org.rhq.core.pc.event.EventManager;
 import org.rhq.core.pc.inventory.InventoryManager;
 import org.rhq.core.pc.inventory.ResourceContainer;
 import org.rhq.core.pc.measurement.MeasurementManager;
-import org.rhq.core.pc.operation.OperationManager;
 import org.rhq.core.pc.plugin.PluginLifecycleListenerManager;
 import org.rhq.core.pc.plugin.PluginLifecycleListenerManagerImpl;
 import org.rhq.core.pc.plugin.PluginManager;
@@ -348,8 +346,7 @@ public class BundleManagerTest {
         public final HashMap<Integer, ResourceContainer> idResourceContainerMap = new HashMap<Integer, ResourceContainer>();
 
         public MockInventoryManager() {
-            super(pcConfig, null, pluginManager, new EventManager(pcConfig), new OperationManager(pcConfig,
-                new MockAgentServiceStreamRemoter()));
+            super(pcConfig, null, pluginManager);
             platformType = new ResourceType("platformResourceTypeName", "pluginName", ResourceCategory.PLATFORM, null);
             bundleHandlerType = new ResourceType("bhRTypeName", "pluginName", ResourceCategory.SERVER, platformType);
             serverTypeFS = new ResourceType("typeName-fileSystem", "pluginName", ResourceCategory.SERVER, platformType);

--- a/modules/core/plugin-container/src/test/java/org/rhq/core/pc/drift/DriftManagerTest.java
+++ b/modules/core/plugin-container/src/test/java/org/rhq/core/pc/drift/DriftManagerTest.java
@@ -49,11 +49,8 @@ import org.rhq.core.domain.drift.DriftSnapshot;
 import org.rhq.core.domain.resource.Resource;
 import org.rhq.core.pc.PluginContainerConfiguration;
 import org.rhq.core.pc.ServerServices;
-import org.rhq.core.pc.bundle.MockAgentServiceStreamRemoter;
-import org.rhq.core.pc.event.EventManager;
 import org.rhq.core.pc.inventory.InventoryManager;
 import org.rhq.core.pc.inventory.ResourceContainer;
-import org.rhq.core.pc.operation.OperationManager;
 import org.rhq.core.pc.plugin.PluginLifecycleListenerManagerImpl;
 import org.rhq.core.pc.plugin.PluginManager;
 
@@ -399,8 +396,7 @@ public class DriftManagerTest extends DriftTest {
         private final Map<Integer, ResourceContainer> resourceContainers = new HashMap<Integer, ResourceContainer>();
 
         public FakeInventoryManager(PluginContainerConfiguration configuration) {
-            super(configuration, null, pluginManager, new EventManager(configuration), new OperationManager(
-                configuration, new MockAgentServiceStreamRemoter()));
+            super(configuration, null, pluginManager);
             initialize();
         }
 


### PR DESCRIPTION
Create and initialize managers in order

Passes rhq-core-plugin-container tests rhq-core-plugin-container-itest tests.
Passes manual testing of an AS7 resource:
- events
- content
- measurement
- operation
  (before and after restart of the plugin container)
