### PR TITLE
[BZ 970784] After successful bundle deployment, discover new resources

### DIFF
--- a/modules/core/client-api/intentional-api-changes-since-4.12.0.xml
+++ b/modules/core/client-api/intentional-api-changes-since-4.12.0.xml
@@ -19,26 +19,29 @@
   -->
 
 <differences>
-    <difference>
-        <className>org/rhq/core/clientapi/server/core/ConnectAgentRequest</className>
-        <differenceType>7004</differenceType> <!-- number of args changed -->
-        <method>ConnectAgentRequest(*)</method>
-        <justification>Only agents use this method and this is needed to fix BZ 1124614</justification>
-    </difference>
-    <difference>
-        <className>org/rhq/core/clientapi/server/core/ConnectAgentResults</className>
-        <differenceType>7004</differenceType> <!-- number of args changed -->
-        <method>ConnectAgentResults(*)</method>
-        <justification>Only agents use this method and this is needed to fix BZ 1124614</justification>
-    </difference>
-    <difference>
-        <className>org/rhq/core/clientapi/server/measurement/MeasurementServerService</className>
-        <differenceType>7012</differenceType> <!-- method added to interface -->
-        <method>org.rhq.core.domain.measurement.MeasurementDataTrait getLastKnownTraitValue(int)</method>
-        <justification>
-            This innterface is not to be implemented outside of RHQ. Also this is a new API so older 
-            versions of the server won't have it. We require version match between server and agent,
-            so we will never be in a situation where a newer agent would be talking to an older server.
-        </justification>               
-    </difference>
+  <difference>
+    <className>org/rhq/core/clientapi/server/core/ConnectAgentRequest</className>
+    <differenceType>7004</differenceType>
+    <!-- number of args changed -->
+    <method>ConnectAgentRequest(*)</method>
+    <justification>Only agents use this method and this is needed to fix BZ 1124614</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/clientapi/server/core/ConnectAgentResults</className>
+    <differenceType>7004</differenceType>
+    <!-- number of args changed -->
+    <method>ConnectAgentResults(*)</method>
+    <justification>Only agents use this method and this is needed to fix BZ 1124614</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/clientapi/server/measurement/MeasurementServerService</className>
+    <differenceType>7012</differenceType>
+    <!-- method added to interface -->
+    <method>org.rhq.core.domain.measurement.MeasurementDataTrait getLastKnownTraitValue(int)</method>
+    <justification>
+      This innterface is not to be implemented outside of RHQ. Also this is a new API so older
+      versions of the server won't have it. We require version match between server and agent,
+      so we will never be in a situation where a newer agent would be talking to an older server.
+    </justification>
+  </difference>
 </differences>

--- a/modules/core/client-api/src/main/java/org/rhq/core/clientapi/agent/discovery/DiscoveryAgentService.java
+++ b/modules/core/client-api/src/main/java/org/rhq/core/clientapi/agent/discovery/DiscoveryAgentService.java
@@ -1,24 +1,20 @@
 /*
  * RHQ Management Platform
- * Copyright (C) 2005-2008 Red Hat, Inc.
+ * Copyright (C) 2005-2014 Red Hat, Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License, version 2, as
- * published by the Free Software Foundation, and/or the GNU Lesser
- * General Public License, version 2.1, also as published by the Free
- * Software Foundation.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License and the GNU Lesser General Public License
- * for more details.
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * and the GNU Lesser General Public License along with this program;
- * if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * along with this program; if not, write to the Free Software Foundation, Inc,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 package org.rhq.core.clientapi.agent.discovery;
 

--- a/modules/core/dbutils/pom.xml
+++ b/modules/core/dbutils/pom.xml
@@ -17,7 +17,7 @@
     <description>Database schema setup, upgrade and other utilities</description>
 
     <properties>
-        <db.schema.version>2.161</db.schema.version>
+        <db.schema.version>2.162</db.schema.version>
         <rhq.ds.type-mapping>${rhq.test.ds.type-mapping}</rhq.ds.type-mapping>
         <rhq.ds.server-name>${rhq.test.ds.server-name}</rhq.ds.server-name>
         <rhq.ds.db-name>${rhq.test.ds.db-name}</rhq.ds.db-name>

--- a/modules/core/dbutils/src/main/scripts/dbsetup/2.4.0/db-schema-combined-2.4.0.xml
+++ b/modules/core/dbutils/src/main/scripts/dbsetup/2.4.0/db-schema-combined-2.4.0.xml
@@ -2217,7 +2217,7 @@
         <column name="STATUS" type="VARCHAR2" required="true" size="16"/>
         <column name="ERROR_MESSAGE" type="LONGVARCHAR" required="false"/>        
         <column name="IS_LIVE" type="BOOLEAN" required="true"/>        
-        <column name="REPLACED_BUNDLE_DEPLOYMENT_ID" type="INTEGER" required="false" references="RHQ_BUNDLE_DEPLOYMENT"/>        
+        <column name="REPLACED_BUNDLE_DEPLOYMENT_ID" type="INTEGER" required="false" references="RHQ_BUNDLE_DEPLOYMENT"/>
     </table>
 
     <!-- Represents a bundle version that is deployed on a platform resource -->

--- a/modules/core/dbutils/src/main/scripts/dbsetup/content-schema.xml
+++ b/modules/core/dbutils/src/main/scripts/dbsetup/content-schema.xml
@@ -573,7 +573,8 @@
         <column name="STATUS" type="VARCHAR2" required="true" size="16"/>
         <column name="ERROR_MESSAGE" type="LONGVARCHAR" required="false"/>        
         <column name="IS_LIVE" type="BOOLEAN" required="true"/>        
-        <column name="REPLACED_BUNDLE_DEPLOYMENT_ID" type="INTEGER" required="false" references="RHQ_BUNDLE_DEPLOYMENT"/>        
+        <column name="REPLACED_BUNDLE_DEPLOYMENT_ID" type="INTEGER" required="false" references="RHQ_BUNDLE_DEPLOYMENT"/>
+        <column name="DISCOVERY_DELAY" type="INTEGER" required="false" />
     </table>
 
     <!-- Represents a bundle version that is deployed on a platform resource -->

--- a/modules/core/dbutils/src/main/scripts/dbupgrade/db-upgrade.xml
+++ b/modules/core/dbutils/src/main/scripts/dbupgrade/db-upgrade.xml
@@ -2565,6 +2565,9 @@
 
             </schemaSpec>
 
+            <schemaSpec version="2.162">
+              <schema-addColumn table="RHQ_BUNDLE_DEPLOYMENT" column="DISCOVERY_DELAY" columnType="INTEGER" />
+            </schemaSpec>
         </dbupgrade>
     </target>
 </project>

--- a/modules/core/domain/intentional-api-changes-since-4.12.0.xml
+++ b/modules/core/domain/intentional-api-changes-since-4.12.0.xml
@@ -188,4 +188,16 @@
     <field>QUERY_FIND_PACKAGE_BY_FILENAME</field>
     <justification>BZ1073691: Unused and non-indexed Query</justification>
   </difference>
+  <difference>
+    <className>org/rhq/core/domain/bundle/BundleDeployment</className>
+    <differenceType>7012</differenceType><!-- method added -->
+    <method>java.lang.Integer getDiscoveryDelay()</method>
+    <justification>BZ 970784, add new property to set delay before automatic discovery of new deployment</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/domain/bundle/BundleDeployment</className>
+    <differenceType>7012</differenceType><!-- method added -->
+    <method>void setDiscoveryDelay(java.lang.Integer)</method>
+    <justification>BZ 970784, add new property to set delay before automatic discovery of new deployment</justification>
+  </difference>
 </differences>

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/bundle/BundleDeployment.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/bundle/BundleDeployment.java
@@ -150,6 +150,9 @@ public class BundleDeployment implements Serializable {
     @ManyToMany(mappedBy = "bundleDeployments", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Set<Tag> tags;
 
+    @Column(name="DISCOVERY_DELAY")
+    private Integer discoveryDelay;
+
     public BundleDeployment() {
         // for JPA use
     }
@@ -160,6 +163,7 @@ public class BundleDeployment implements Serializable {
         this.name = name;
         this.status = BundleDeploymentStatus.PENDING;
         this.isLive = false;
+        this.discoveryDelay = Integer.valueOf(30);
     }
 
     public int getId() {
@@ -340,6 +344,14 @@ public class BundleDeployment implements Serializable {
         }
         this.resourceDeployments.add(resourceDeployment);
         resourceDeployment.setBundleDeployment(this);
+    }
+
+    public Integer getDiscoveryDelay() {
+        return discoveryDelay;
+    }
+
+    public void setDiscoveryDelay(Integer discoveryDelay) {
+        this.discoveryDelay = discoveryDelay;
     }
 
     public Set<Tag> getTags() {

--- a/modules/core/plugin-container/src/main/java/org/rhq/core/pc/inventory/InventoryManager.java
+++ b/modules/core/plugin-container/src/main/java/org/rhq/core/pc/inventory/InventoryManager.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -786,9 +787,13 @@ public class InventoryManager extends AgentService implements ContainerService, 
 
     @Override
     public void executeServiceScanDeferred(int resourceId) {
+        executeServiceScanDeferred(resourceId, 0);
+    }
+
+    public void executeServiceScanDeferred(int resourceId, long scanDelayInMillis) {
         Resource resource = getResourceContainer(resourceId).getResource();
         RuntimeDiscoveryExecutor discoveryExecutor = new RuntimeDiscoveryExecutor(this, this.configuration, resource);
-        inventoryThreadPoolExecutor.submit((Runnable) discoveryExecutor);
+        inventoryThreadPoolExecutor.schedule((Runnable) discoveryExecutor, scanDelayInMillis, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages.properties
@@ -1450,6 +1450,7 @@ view_bundle_deployWizard_deploymentScheduledDetail = You have scheduled the bund
 view_bundle_deployWizard_deploymentScheduledDetail_concise = You have scheduled the bundle deployment
 view_bundle_deployWizard_destinationCreatedDetail = You have created the destination [{0}] with the description [{1}]
 view_bundle_deployWizard_destinationCreatedDetail_concise = You have created the destination [{0}]
+view_bundle_deployWizard_discoveryDelay = Delay in seconds before automatic discovery attempt happens after successful deployment. Values below zero (0) disable this feature.
 view_bundle_deployWizard_error_1 = Failed to delete new deployment on Cancel
 view_bundle_deployWizard_error_10 = Failed to create destination, it may already exist. (Note, for an existing destination deploy from the Destination view)
 view_bundle_deployWizard_error_11 = Failed to find defined deployments.

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_cs.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_cs.properties
@@ -2530,3 +2530,4 @@ widget_typeCache_loadFail = Nepodařilo se načíst metadata typu zdroje.
 widget_typeTree_badTemplateType = Neplatné URL. Neznámy typ šablony: [{0}]
 widget_typeTree_badTypeId = Neplatné URL. Špatný typ zdroje ID: [{0}]
 widget_typeTree_loadFail = Nepodařilo se načíst typy zdrojů
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_de.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_de.properties
@@ -3031,3 +3031,4 @@ widget_typeCache_loadFail = Konnte die Metadaten für den Ressourcen-Typ nicht l
 widget_typeTree_badTemplateType = Ungültige URL. Unbekannter Vorlagen-Typ [{0}]
 widget_typeTree_badTypeId = Ungültige URL. Unbekannte Ressource-Typ-ID [{0}]
 widget_typeTree_loadFail = Konnte die Ressource-Typen nicht laden
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_ja.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_ja.properties
@@ -2562,3 +2562,4 @@ widget_typeCache_loadFail = リソースタイプメタデータのロードに�
 widget_typeTree_badTemplateType = 無効なURL。未知のテンプレートタイプ [{0}]
 widget_typeTree_badTypeId = 無効なURL。不正なリソースタイプ [{0}]
 widget_typeTree_loadFail = リソースタイプのロードに失敗しました
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_ko.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_ko.properties
@@ -2149,3 +2149,4 @@ widget_resourceSelector_pleaseSelectMultipleResource = 하나 이상의 리소�
 widget_resourceSelector_pleaseSelectResource = 리소스를 선택하십시오
 widget_resourceSelector_selectMultipleResources = 리소스를 선택
 widget_resourceSelector_selectResource = 리소스를 선택
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_pt.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_pt.properties
@@ -2609,3 +2609,4 @@ widget_typeCache_loadFail = Falha ao carregar o metadado do tipo de recurso
 widget_typeTree_badTemplateType = URL inv\u00E1lida. Tipo de template desconhecido [{0}]
 widget_typeTree_badTypeId = URL inv\u00E1lida. Tipo de recurso inv\u00E1lido: ID [{0}]
 widget_typeTree_loadFail = Falha ao carregar tipos de recurso
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_ru.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_ru.properties
@@ -3217,3 +3217,4 @@ view_group_detail_implicitAvail = Group availability for all members (includes r
 ##view_searchBar_suggest_failSuggest = Failed to generate suggestions, see server log for possible errors
 ##view_searchBar_suggest_noSuggest = No matches, enter a different pattern
 view_tabs_common_graphs_cubism = Cubism графики
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_zh.properties
+++ b/modules/enterprise/gui/coregui/src/main/resources/org/rhq/coregui/client/Messages_zh.properties
@@ -2497,3 +2497,4 @@ widget_typeCache_loadFail = \u65e0\u6cd5\u52a0\u8f7d\u8d44\u6e90\u7c7b\u578b\u76
 widget_typeTree_badTemplateType = \u65e0\u6548\u7684URL. \u672a\u77e5\u6a21\u677f\u7c7b\u578b[{0}]
 widget_typeTree_badTypeId = \u65e0\u6548URL. \u9519\u8bef\u8d44\u6e90\u7c7b\u578bID [{0}]
 widget_typeTree_loadFail = \u52a0\u8f7d\u8d44\u6e90\u7c7b\u578b\u5931\u8d25
+view_bundle_deployWizard_discoveryDelay=

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/bundle/BundleManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/bundle/BundleManagerBean.java
@@ -16,7 +16,6 @@
  * along with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
-
 package org.rhq.enterprise.server.bundle;
 
 import java.io.ByteArrayInputStream;
@@ -87,6 +86,7 @@ import org.rhq.core.domain.bundle.composite.BundleGroupAssignmentComposite;
 import org.rhq.core.domain.bundle.composite.BundleWithLatestVersionComposite;
 import org.rhq.core.domain.configuration.Configuration;
 import org.rhq.core.domain.configuration.ConfigurationUtility;
+import org.rhq.core.domain.configuration.PropertySimple;
 import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
 import org.rhq.core.domain.content.Architecture;
 import org.rhq.core.domain.content.Package;
@@ -373,6 +373,11 @@ public class BundleManagerBean implements BundleManagerLocal, BundleManagerRemot
         deployment.setDescription(description);
         deployment.setConfiguration(configuration);
         deployment.setSubjectName(subject.getName());
+
+        PropertySimple discoveryDelayProperty = configuration.getSimple("org.rhq.discoveryDelay");
+        if(discoveryDelayProperty != null) {
+            deployment.setDiscoveryDelay(discoveryDelayProperty.getIntegerValue());
+        }
 
         entityManager.persist(deployment);
 
@@ -937,8 +942,8 @@ public class BundleManagerBean implements BundleManagerLocal, BundleManagerRemot
         // !!!! NEW BEHAVIOR SINCE 4.13 - we fail the bundle version creation when we cannot determine the set
         // of the files the bundle version should be comprised of.
         if (info.getBundleFiles() == null && info.getRecipeParseResults().getBundleFileNames() == null) {
-            throw new IllegalArgumentException("Cannot create a bundle version without files determined by the recipe"
-                + " or provided explicitly during bundle version creation.");
+            throw new IllegalArgumentException("Cannot create a bundle version without files determined by the recipe" +
+                " or provided explicitly during bundle version creation.");
         }
 
         BundleType bundleType = bundleManager.getBundleType(subject, info.getBundleTypeName());

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/ConfigurationManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/ConfigurationManagerBean.java
@@ -1,6 +1,6 @@
 /*
  * RHQ Management Platform
- * Copyright (C) 2005-2013 Red Hat, Inc.
+ * Copyright (C) 2005-2014 Red Hat, Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * along with this program; if not, write to the Free Software Foundation, Inc,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/scheduler/jobs/BundleDeploymentStatusCheckJob.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/scheduler/jobs/BundleDeploymentStatusCheckJob.java
@@ -1,6 +1,6 @@
 /*
  * RHQ Management Platform
- * Copyright (C) 2013 Red Hat, Inc.
+ * Copyright (C) 2005-2014 Red Hat, Inc.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -13,8 +13,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * along with this program; if not, write to the Free Software Foundation, Inc,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
 package org.rhq.enterprise.server.scheduler.jobs;
@@ -29,6 +29,7 @@ import org.quartz.Trigger;
 
 import org.rhq.core.domain.auth.Subject;
 import org.rhq.core.domain.bundle.BundleDeployment;
+import org.rhq.core.domain.bundle.BundleDeploymentStatus;
 import org.rhq.core.domain.criteria.BundleDeploymentCriteria;
 import org.rhq.core.domain.util.PageList;
 import org.rhq.enterprise.server.auth.SubjectManagerLocal;
@@ -75,9 +76,11 @@ public class BundleDeploymentStatusCheckJob implements Job {
             SchedulerLocal scheduler = LookupUtil.getSchedulerBean();
             JobDetail jobDetail = context.getJobDetail();
 
-            if (bundleManager.determineBundleDeploymentStatus(bundleDeployment.getId()).isTerminal()) {
+            BundleDeploymentStatus bundleDeploymentStatus = bundleManager.determineBundleDeploymentStatus(bundleDeployment.getId());
+            if (bundleDeploymentStatus.isTerminal()) {
                 // delete this job, we've assigned a final status
                 try {
+                    context.setResult(bundleDeploymentStatus); // Return status to possible listeners
                     scheduler.deleteJob(jobDetail.getName(), jobDetail.getGroup());
                 } catch (SchedulerException e) {
                     throw new JobExecutionException("Could not delete the bundle deployment completion check job for "


### PR DESCRIPTION
After a successful bundle deployment, initiate resource discovery for all the affected resources. This should ensure that user doesn't have to manually add new resources to their inventory (or force discovery process).
