### PR TITLE
Bug 1038317 - Use of remote client API results in error/warning messages...

### DIFF
--- a/modules/enterprise/remoting/cli/pom.xml
+++ b/modules/enterprise/remoting/cli/pom.xml
@@ -125,6 +125,8 @@
                            <property name="jboss-logging.version" value="${jboss-logging.version}" />
                            <property name="jboss-remoting.version" value="${jboss-remoting.version}" />
                            <property name="jboss-javassist.version" value="${javassist.version}" />
+                           <property name="hibernate-jpa-2.0-api.version" value="${hibernate-jpa-2.0-api.version}" />
+                           <property name="hibernate.version" value="${hibernate.version}" />
                            <property name="jline.version" value="${jline.version}" />
                            <property name="log4j.version" value="${log4j.version}" />
                            <property name="testng.version" value="${testng.version}" />

--- a/modules/enterprise/remoting/cli/src/main/scripts/rhq-client.build.xml
+++ b/modules/enterprise/remoting/cli/src/main/scripts/rhq-client.build.xml
@@ -61,9 +61,8 @@
       <copy file="${settings.localRepository}/org/jboss/remoting/jboss-remoting/${jboss-remoting.version}/jboss-remoting-${jboss-remoting.version}.jar" tofile="${lib.home}/jboss-remoting-${jboss-remoting.version}.jar" verbose="true" />
       <copy file="${settings.localRepository}/org/javassist/javassist/${jboss-javassist.version}/javassist-${jboss-javassist.version}.jar" tofile="${lib.home}/javassist-${jboss-javassist.version}.jar" verbose="true" />
       <copy file="${settings.localRepository}/oswego-concurrent/concurrent/${concurrent.version}/concurrent-${concurrent.version}.jar" tofile="${lib.home}/concurrent-${concurrent.version}.jar" verbose="true" />
-      <!-- TODO: This can probaby go away after we stop using EJB classes as Exceptions in the RemoteAPI (TODO (jshaughn): add back if necessary)
-      <copy file="${settings.localRepository}/javax/persistence/persistence-api/${persistence-api.version}/persistence-api-${persistence-api.version}.jar" tofile="${lib.home}/persistence-api-${persistence-api.version}.jar" verbose="true" />      
-      -->
+      <copy file="${settings.localRepository}/org/hibernate/javax/persistence/hibernate-jpa-2.0-api/${hibernate-jpa-2.0-api.version}/hibernate-jpa-2.0-api-${hibernate-jpa-2.0-api.version}.jar" tofile="${lib.home}/hibernate-jpa-2.0-api-${hibernate-jpa-2.0-api.version}.jar" verbose="true" />
+      <copy file="${settings.localRepository}/org/hibernate/hibernate-core/${hibernate.version}/hibernate-core-${hibernate.version}.jar" tofile="${lib.home}/hibernate-core-${hibernate.version}.jar" verbose="true" />
       <copy file="${basedir}/target/${project.artifactId}-${project.version}.jar" tofile="${lib.home}/${project.artifactId}-${project.version}.jar" verbose="true" />
       <copy file="${settings.localRepository}/net/sf/opencsv/opencsv/${opencsv.version}/opencsv-${opencsv.version}.jar" tofile="${lib.home}/opencsv-${opencsv.version}.jar" verbose="true" />
    	  <copy file="${settings.localRepository}/org/rhq/rhq-script-bindings/${project.version}/rhq-script-bindings-${project.version}.jar" tofile="${lib.home}/rhq-script-bindings-${project.version}.jar" verbose="true" />

--- a/modules/enterprise/remoting/client-deps/pom.xml
+++ b/modules/enterprise/remoting/client-deps/pom.xml
@@ -27,23 +27,19 @@
 	         <groupId>javax.xml.bind</groupId>
 	         <artifactId>jaxb-api</artifactId>
 	       </exclusion>
-       <exclusion>
-         <groupId>antlr</groupId>
-         <artifactId>antlr</artifactId>
-       </exclusion>
-       <exclusion>
-	     <groupId>org.antlr</groupId>
-	     <artifactId>antlr</artifactId>
-	   </exclusion>
            <exclusion>
-	     <groupId>hibernate-annotations</groupId>
-	     <artifactId>hibernate-annotations</artifactId>
-	   </exclusion>
+             <groupId>antlr</groupId>
+             <artifactId>antlr</artifactId>
+           </exclusion>
            <exclusion>
-	     <groupId>com.jcraft</groupId>
-	     <artifactId>jsch</artifactId>
-	   </exclusion>
-	 </exclusions>
+             <groupId>org.antlr</groupId>
+             <artifactId>antlr</artifactId>
+           </exclusion>
+           <exclusion>
+             <groupId>com.jcraft</groupId>
+             <artifactId>jsch</artifactId>
+           </exclusion>
+         </exclusions>
       </dependency>
 
     <dependency>


### PR DESCRIPTION
... regarding indirectly referenced JPA annotations not being resolvable

Added Hibernate Core (for CascadeType enum) and Hibernate JPA Annotations to the CLI distribution

Tested with the wiki remote API example https://docs.jboss.org/author/display/RHQ/Java+Client+Sample+Class
(Only 1 warning remains at compilation, because the sample class uses a deprecated method from the Remote API)
