### PR TITLE
1149265 - Main menu bar appears on top of Favorites menu in IE

### DIFF
--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/footer/FavoritesMenu.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/footer/FavoritesMenu.java
@@ -48,9 +48,6 @@ import org.rhq.coregui.client.inventory.resource.type.ResourceTypeRepository;
 import org.rhq.coregui.client.inventory.resource.type.ResourceTypeRepository.TypesLoadedCallback;
 
 /**
- * @author Greg Hinkle
- * @author Ian Springer
- * @author John Mazzitelli
  * @author Jay Shaughnessy
  */
 public class FavoritesMenu extends Menu {
@@ -334,7 +331,6 @@ public class FavoritesMenu extends Menu {
                                 callback.onSuccess(new Favorites(resources, groups));
                             }
                         });
-
                 }
             });
     }
@@ -366,5 +362,4 @@ public class FavoritesMenu extends Menu {
             return null;
         }
     }
-
 }

--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/menu/MenuBarView.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/menu/MenuBarView.java
@@ -191,6 +191,7 @@ public class MenuBarView extends EnhancedVLayout {
         favoritesMenu = new FavoritesMenu();
         messageBar = new MessageBar();
         messageBar.setVisible(false);
+
         injectMenuFunctions(this);
         new PermissionsLoader().loadExplicitGlobalPermissions(new PermissionsLoadedListener() {
             @Override
@@ -199,9 +200,7 @@ public class MenuBarView extends EnhancedVLayout {
                 for (MenuItem item : MENU_ITEMS) {
                     updateMenuVisibility(item);
                 }
-                LinkBar linkBar = new LinkBar();
-                messageBar.setOverridingCanvas(linkBar);
-                addMember(linkBar);
+                addMember(new LinkBar());
                 addMember(messageBar);
             }
         });
@@ -220,24 +219,33 @@ public class MenuBarView extends EnhancedVLayout {
         }
     }
 
- // This is our JSNI method that will be called on form submit
+    // This is our JSNI method that will be called on form submit
     private native void injectMenuFunctions(MenuBarView view) /*-{
-      $wnd.__gwt_showMessageCenter = $entry(function(){
-        view.@org.rhq.coregui.client.menu.MenuBarView::showMessageCenterWindow()();
-      });
+                                                              $wnd.__gwt_clearMessageBar = $entry(function(){
+                                                              view.@org.rhq.coregui.client.menu.MenuBarView::clearMessageBar()();
+                                                              });
 
-      $wnd.__gwt_showFavoritesMenu = $entry(function(){
-        view.@org.rhq.coregui.client.menu.MenuBarView::showFavoritesMenu()();
-      });
+                                                              $wnd.__gwt_showMessageCenter = $entry(function(){
+                                                              view.@org.rhq.coregui.client.menu.MenuBarView::showMessageCenterWindow()();
+                                                              });
 
-      $wnd.__gwt_showAboutBox = $entry(function(){
-        view.@org.rhq.coregui.client.menu.MenuBarView::showAboutBox()();
-      });
-    }-*/;
+                                                              $wnd.__gwt_showFavoritesMenu = $entry(function(){
+                                                              view.@org.rhq.coregui.client.menu.MenuBarView::showFavoritesMenu()();
+                                                              });
+
+                                                              $wnd.__gwt_showAboutBox = $entry(function(){
+                                                              view.@org.rhq.coregui.client.menu.MenuBarView::showAboutBox()();
+                                                              });
+                                                              }-*/;
+
+    // called via JSNI - user menu button
+    public void clearMessageBar() {
+        messageBar.clearMessage(true);
+    }
 
     // called via JSNI - fav menu button
     public void showFavoritesMenu() {
-        // lazily show the favs menu, in that way it shows up on top of the menu item bar
+        clearMessageBar();
         favoritesMenu.show();
         this.favoritesMenu.showMenu(DOM.getElementById(BTN_FAV_ID).getAbsoluteBottom(), DOM.getElementById(BTN_FAV_ID)
             .getAbsoluteLeft());
@@ -334,8 +342,8 @@ public class MenuBarView extends EnhancedVLayout {
            +"<li>"
            +"<a id='"+BTN_MSG_CENTER_ID+"' onclick='__gwt_showMessageCenter(); return false;'>"+MSG_CENTER_BTN_CONTENT+"0</a>"
          +"</li>"
-           +"<li class='dropdown'>"
-                + "<a class='dropdown-toggle' data-toggle='dropdown'>"
+                + "<li class='dropdown'>"
+                + "<a onclick='__gwt_clearMessageBar(); return false;' class='dropdown-toggle' data-toggle='dropdown'>"
                +"<span class='pficon pficon-user'></span>"
                 +user.getName()+" <b class='caret'></b>"
              +"</a>"
@@ -531,5 +539,4 @@ public class MenuBarView extends EnhancedVLayout {
             return hidden;
         }
     }
-
 }

--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/util/message/MessageBar.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/util/message/MessageBar.java
@@ -1,6 +1,6 @@
 /*
  * RHQ Management Platform
- * Copyright 2010-2014, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2010-2011, Red Hat Middleware LLC, and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -53,6 +53,7 @@ import org.rhq.coregui.client.util.message.Message.Severity;
  */
 public class MessageBar extends Canvas implements MessageCenter.MessageListener, Enhanced {
 
+    public static final int Z_INDEX = 999998;
     private static final int AUTO_HIDE_DELAY_MILLIS = 30000;
     private static final String NON_BREAKING_SPACE = "&nbsp;";
 
@@ -61,11 +62,9 @@ public class MessageBar extends Canvas implements MessageCenter.MessageListener,
     private Message stickyMessage; // this message will always be shown until dismissed by user.
     private Menu showDetailsMenu;
     private Timer messageClearingTimer;
-    private Canvas overridingCanvas;
 
     public MessageBar() {
         super();
-
         setOverflow(Overflow.VISIBLE);
         setHeight(1);
         setWidth(1);
@@ -166,15 +165,6 @@ public class MessageBar extends Canvas implements MessageCenter.MessageListener,
         }
     }
 
-    /**
-     * A canvas whose z-index will have (+1) higher priority that than the message bar.
-     * TODO: not yet needed, but another canvas setting may be useful for a (-1) z-index
-     * @param overridingCanvas
-     */
-    public void setOverridingCanvas(Canvas overridingCanvas) {
-        this.overridingCanvas = overridingCanvas;
-    }
-
     public void reset() {
         clearMessage(true);
     }
@@ -198,21 +188,20 @@ public class MessageBar extends Canvas implements MessageCenter.MessageListener,
         +"<span class='pficon pficon-close'></span>"
         +"</button>";
         StringBuilder sb = new StringBuilder();
-        int zIndex = null == overridingCanvas ? 0 : overridingCanvas.getZIndex() - 1;
         switch (severity) {
             case Blank: {
-            sb.append("<div class='alert alert-success' style='float:right; z-index: " + zIndex + ";'>");
+            sb.append("<div class='alert alert-success' style='float:right; z-index: " + Z_INDEX + ";'>");
                 sb.append("<span class='pficon pficon-ok'></span>");
                 break;
             }
             case Info: {
-            sb.append("<div class='alert alert-info' style='float:right; z-index: " + zIndex + ";'>");
+            sb.append("<div class='alert alert-info' style='float:right; z-index: " + Z_INDEX + ";'>");
                 sb.append(closeBtn);
                 sb.append("<span class='pficon pficon-info'></span>");
                 break;
             }
             case Warning: {
-            sb.append("<div class='alert alert-warning' style='float:right; z-index: " + zIndex + ";'>");
+            sb.append("<div class='alert alert-warning' style='float:right; z-index: " + Z_INDEX + ";'>");
                 sb.append(closeBtn);
                 sb.append("<span class='pficon-layered'>");
                 sb.append("  <span class='pficon pficon-warning-triangle'></span>");
@@ -222,7 +211,7 @@ public class MessageBar extends Canvas implements MessageCenter.MessageListener,
             }
             case Fatal:
             case Error: {
-            sb.append("<div class='alert alert-danger' style='float:right; z-index: " + zIndex + ";'>");
+            sb.append("<div class='alert alert-danger' style='float:right; z-index: " + Z_INDEX + ";'>");
                 sb.append(closeBtn);
                 sb.append("<span class='pficon-layered'>");
                 sb.append("  <span class='pficon pficon-error-octagon'></span>");
@@ -231,7 +220,7 @@ public class MessageBar extends Canvas implements MessageCenter.MessageListener,
                 break;
             }
             default: {
-            sb.append("<div class='alert alert-info' style='z-index: " + zIndex + ";'>");
+            sb.append("<div class='alert alert-info' style='z-index: " + Z_INDEX + ";'>");
                 sb.append(closeBtn);
                 sb.append("<span class='pficon pficon-info'></span>");
             }
@@ -264,5 +253,4 @@ public class MessageBar extends Canvas implements MessageCenter.MessageListener,
         content.redraw();
         content.show();
     }
-
 }


### PR DESCRIPTION
- Delete class FavoritesButton, the button was no longer used.
- Create FavoritesMenu,  just the Menu part of the former button class
- Remove various explicit zIndex setting and defer to the css defs in
  play due to the recent work for BZ 1144052.
- Remove the '#' href from the current user dropdown, it navigated
  to nowhere on a click of the button.
- Fix I18N issue in user dropdown. Replace literal "Account Details" with
  "Settings" property. (note, could not add new property for release, so
  chose "Settings" as best existing prop).
