### PR TITLE
Bug 1130392 - Sigar cannot detect kernel thread names

### DIFF
--- a/modules/core/native-system/src/main/java/org/rhq/core/system/ProcessInfo.java
+++ b/modules/core/native-system/src/main/java/org/rhq/core/system/ProcessInfo.java
@@ -40,6 +40,7 @@ import org.hyperic.sigar.ProcCredName;
 import org.hyperic.sigar.ProcExe;
 import org.hyperic.sigar.ProcFd;
 import org.hyperic.sigar.ProcMem;
+import org.hyperic.sigar.ProcStat;
 import org.hyperic.sigar.ProcState;
 import org.hyperic.sigar.ProcTime;
 import org.hyperic.sigar.Sigar;
@@ -518,9 +519,7 @@ public class ProcessInfo {
         } else if ((procExe != null) && (procExe.getName() != null)) {
             name = procExe.getName();
         } else if ((procState != null) && (procState.getName() != null)) {
-            String stateName = procState.getName();
-            name = ((stateName.indexOf(File.separatorChar) >= 0) && (new File(stateName).exists())) ? stateName
-                : UNKNOWN_PROCESS_NAME;
+            name = procState.getName();
         } else {
             name = UNKNOWN_PROCESS_NAME;
         }


### PR DESCRIPTION
Sigar does detect the name of kernel threads, it's RHQ that has been filtering
them out.

The fix is simply removing the check for filename existence, and kernel thread
names don't have files anyway.
