### PR TITLE
Bz1095508 - MacOS - rhq-cli.sh script command fails with 'readlink: illegal option -- f

### DIFF
--- a/modules/enterprise/remoting/cli/src/etc/rhq-cli.sh
+++ b/modules/enterprise/remoting/cli/src/etc/rhq-cli.sh
@@ -148,11 +148,6 @@ else
         fi
     fi
 
-
-    #readlink_rhq "$RHQ_CLI_HOME"
-    #get an absolute path
-    #RHQ_CLI_HOME=`readlink -f "$RHQ_CLI_HOME"`
-
     if [ ! -d "$RHQ_CLI_HOME" ]; then
         echo "RHQ_CLI_HOME detected or defined as [$RHQ_CLI_HOME] doesn't seem to exist or is not a directory"
         exit 1


### PR DESCRIPTION
This fixes the mac OS/X readline issue so that the cli can run on OS/X now. Ready for review. Script gurus feel free to refactor.
