### PR TITLE
Ensure that the server and agent scripts propagate SIGTERM in foreground...

### DIFF
--- a/modules/enterprise/agent/src/etc/rhq-agent.sh
+++ b/modules/enterprise/agent/src/etc/rhq-agent.sh
@@ -320,7 +320,12 @@ debug_msg "$CMD"
 
 # Run the VM - put it in background if the caller wants it to be
 if [ -z "$RHQ_AGENT_IN_BACKGROUND" ]; then
-   eval "$CMD"
+   trap 'kill -TERM $RHQ_AGENT_PID' TERM INT
+   eval "$CMD &"
+   RHQ_AGENT_PID=$!
+   wait $RHQ_AGENT_PID
+   trap - TERM INT
+   wait $RHQ_AGENT_PID
 else
    eval "$CMD &"
    RHQ_AGENT_BACKGROUND_PID=$!

--- a/modules/enterprise/server/appserver/src/main/bin-resources/bin/internal/rhq-server.sh
+++ b/modules/enterprise/server/appserver/src/main/bin-resources/bin/internal/rhq-server.sh
@@ -459,8 +459,12 @@ case "$1" in
         # START SERVER
         # first, make sure its working directory is the JBossAS bin directory
         cd "${RHQ_SERVER_JBOSS_HOME}/bin"
-        "$_JBOSS_RUN_SCRIPT" $_CMDLINE_OPTS
-
+        trap 'kill -TERM $PID' TERM INT
+        LAUNCH_JBOSS_IN_BACKGROUND=1 "$_JBOSS_RUN_SCRIPT" $_CMDLINE_OPTS &
+        PID=$!
+        wait $PID
+        trap - TERM INT
+        wait $PID
         _JBOSS_STATUS=$?
 
         remove_pid_files


### PR DESCRIPTION
... mode

Supervisord requires that programs (1) don't daemonize themselves and
(2) respond to SIGTERM by properly shutting down. Requirement (1) is satisfied
provided one uses the following commands:
- rhq-server/rhq-storage/bin/cassandra -f
- rhq-server/bin/internal/rhq-server.sh console
- rhq-agent/bin/rhq-agent.sh -d
  This patch modifies rhq-server.sh and rhq-agent.sh so that they also satisfy
  requirement (2). Note that Cassandra already satisfies that requirement because
  the script uses exec to launch the JVM.

With this change, RHQ can be properly configured to run under Supervisord, e.g.
in a Docker container.
