### PR TITLE
Bug 1168890 - Remove InventoryStatus.DELETED resource state

### DIFF
--- a/modules/core/client-api/intentional-api-changes-since-4.13.0.xml
+++ b/modules/core/client-api/intentional-api-changes-since-4.13.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+  ~ RHQ Management Platform
+  ~ Copyright (C) 2005-2014 Red Hat, Inc.
+  ~ All rights reserved.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation version 2 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software Foundation, Inc.,
+  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+  -->
+
+<differences>
+  <difference>
+    <className>org/rhq/core/clientapi/agent/inventory/DeleteResourceResponse</className>
+    <differenceType>7004</differenceType>
+    <!-- number of args changed -->
+    <method>DeleteResourceResponse(int, org.rhq.core.domain.resource.DeleteResourceStatus, java.lang.String)</method>
+    <justification>
+        BZ 1168890 - DeleteResourceResponse now holds ID of deleted resource as we no longer persist 
+        reference to deleted Resource in DeleteResourceHistory
+    </justification>
+  </difference>
+</differences>

--- a/modules/core/client-api/src/main/java/org/rhq/core/clientapi/agent/inventory/DeleteResourceResponse.java
+++ b/modules/core/client-api/src/main/java/org/rhq/core/clientapi/agent/inventory/DeleteResourceResponse.java
@@ -23,6 +23,7 @@
 package org.rhq.core.clientapi.agent.inventory;
 
 import java.io.Serializable;
+
 import org.rhq.core.domain.resource.DeleteResourceStatus;
 
 /**
@@ -32,6 +33,7 @@ public class DeleteResourceResponse implements Serializable {
     // Attributes  --------------------------------------------
 
     private int requestId;
+    private int resourceId;
     private DeleteResourceStatus status;
     private String errorMessage;
 
@@ -40,8 +42,9 @@ public class DeleteResourceResponse implements Serializable {
     public DeleteResourceResponse() {
     }
 
-    public DeleteResourceResponse(int requestId, DeleteResourceStatus status, String errorMessage) {
+    public DeleteResourceResponse(int requestId, int resourceId, DeleteResourceStatus status, String errorMessage) {
         this.requestId = requestId;
+        this.resourceId = resourceId;
         this.status = status;
         this.errorMessage = errorMessage;
     }
@@ -54,6 +57,14 @@ public class DeleteResourceResponse implements Serializable {
 
     public void setRequestId(int requestId) {
         this.requestId = requestId;
+    }
+
+    public int getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(int resourceId) {
+        this.resourceId = resourceId;
     }
 
     public DeleteResourceStatus getStatus() {

--- a/modules/core/dbutils/pom.xml
+++ b/modules/core/dbutils/pom.xml
@@ -18,7 +18,7 @@
     <description>Database schema setup, upgrade and other utilities</description>
 
     <properties>
-        <db.schema.version>2.165</db.schema.version>
+        <db.schema.version>2.166</db.schema.version>
         <rhq.ds.type-mapping>${rhq.test.ds.type-mapping}</rhq.ds.type-mapping>
         <rhq.ds.server-name>${rhq.test.ds.server-name}</rhq.ds.server-name>
         <rhq.ds.db-name>${rhq.test.ds.db-name}</rhq.ds.db-name>

--- a/modules/core/dbutils/src/main/scripts/dbsetup/resource-request-schema.xml
+++ b/modules/core/dbutils/src/main/scripts/dbsetup/resource-request-schema.xml
@@ -25,7 +25,10 @@
         <column name="CTIME" type="LONG" required="true"/>
         <column name="MTIME" type="LONG" required="true"/>
         <column name="STATUS" type="VARCHAR2" required="true" size="16"/>
-        <column name="RESOURCE_ID" type="INTEGER" required="true" references="RHQ_RESOURCE"/>
+        <column name="PARENT_RESOURCE_ID" type="INTEGER" required="true" references="RHQ_RESOURCE"/>
+        <column name="RESOURCE_TYPE_ID" type="INTEGER" required="true" references="RHQ_RESOURCE_TYPE" />
+        <column name="RESOURCE_NAME" type="VARCHAR2" required="true" size="500" />
+        <column name="RESOURCE_KEY" type="VARCHAR2" required="true" size="500" />
     </table>
 
 </dbsetup>

--- a/modules/core/dbutils/src/main/scripts/dbupgrade/db-upgrade.xml
+++ b/modules/core/dbutils/src/main/scripts/dbupgrade/db-upgrade.xml
@@ -2599,6 +2599,67 @@
               </schema-directSQL>
             </schemaSpec>
 
+            <schemaSpec version="2.166">
+              <!-- removed InventoryStatus.DELETED -->
+              <schema-addColumn table="RHQ_DELETE_RES_HIST" column="PARENT_RESOURCE_ID" columnType="INTEGER" />
+              <schema-directSQL>
+                <statement>
+                  ALTER TABLE RHQ_DELETE_RES_HIST
+                  ADD CONSTRAINT RHQ_DELETE_RES_HIST_PARENT_RESOURCE_ID_ID_FK
+                  FOREIGN KEY ( PARENT_RESOURCE_ID ) REFERENCES RHQ_RESOURCE ( ID )
+                </statement>
+              </schema-directSQL>
+              <schema-addColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_TYPE_ID" columnType="INTEGER" />
+              <schema-directSQL>
+                <statement>
+                  ALTER TABLE RHQ_DELETE_RES_HIST
+                  ADD CONSTRAINT RHQ_DELETE_RES_HIST_RESOURCE_TYPE_ID_ID_FK
+                  FOREIGN KEY ( RESOURCE_TYPE_ID ) REFERENCES RHQ_RESOURCE_TYPE ( ID )
+                </statement>
+              </schema-directSQL>
+              <schema-directSQL>
+                <statement>
+                  ALTER TABLE RHQ_DELETE_RES_HIST DROP CONSTRAINT RHQ_DELETE_RES_HIST_RESOURCE_ID_FKEY
+                </statement>
+              </schema-directSQL>
+              <schema-addColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_NAME" columnType="VARCHAR2" precision="500" />
+              <schema-addColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_KEY" columnType="VARCHAR2" precision="500" />
+              <schema-directSQL ignoreError="true">
+                <statement desc="Migrate data in RHQ_DELETE_RES_HIST - set RESOURCE_ID to NULL and update RESOURCE_TYPE_ID, RESOURCE_KEY and RESOURCE_NAME columns">
+                  UPDATE rhq_delete_res_hist
+                  SET 
+                  parent_resource_id = rhq_resource.parent_resource_id,
+                  resource_name = rhq_resource.name,
+                  resource_key = rhq_resource.resource_key,
+                  resource_type_id = rhq_resource_type.id
+                  FROM rhq_resource, rhq_resource_type
+                  WHERE rhq_resource.id = rhq_delete_res_hist.resource_id and rhq_resource.resource_type_id = rhq_resource_type.id
+                </statement>
+              </schema-directSQL>
+              <schema-alterColumn table="RHQ_DELETE_RES_HIST" column="PARENT_RESOURCE_ID" nullable="FALSE" />
+              <schema-alterColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_TYPE_ID" nullable="FALSE" />
+              <schema-alterColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_NAME" nullable="FALSE" />
+              <schema-deleteColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_ID" />
+              <schema-alterColumn table="RHQ_DELETE_RES_HIST" column="RESOURCE_KEY" nullable="FALSE" />
+              <!-- prepare the DELETED resources to be picked up by async uninventory job -->
+              <schema-directSQL ignoreError="true">
+                <statement desc="Remove resources with InventoryStatus = DELETED from implicit resource groups">
+                  DELETE FROM RHQ_RESOURCE_GROUP_RES_IMP_MAP WHERE RESOURCE_ID IN ( SELECT id FROM rhq_resource WHERE inventory_status = 'DELETED' )
+                </statement>
+                <statement desc="Remove resources with InventoryStatus = DELETED from explicit resource groups">
+                  DELETE FROM RHQ_RESOURCE_GROUP_RES_EXP_MAP WHERE RESOURCE_ID IN ( SELECT id FROM rhq_resource WHERE inventory_status = 'DELETED' )
+                </statement>
+                <statement desc="Mark resources with InventoryStatus = DELETED for async uninventory">
+                  UPDATE rhq_resource
+                  SET inventory_status = 'UNINVENTORIED',
+                  agent_id = NULL,
+                  parent_resource_id = NULL,
+                  resource_key = 'deleted'
+                  WHERE inventory_status = 'DELETED'
+                </statement>
+              </schema-directSQL>
+            </schemaSpec>
+
         </dbupgrade>
     </target>
 </project>

--- a/modules/core/domain/intentional-api-changes-since-4.13.0.xml
+++ b/modules/core/domain/intentional-api-changes-since-4.13.0.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!--
+  ~ RHQ Management Platform
+  ~ Copyright (C) 2005-2014 Red Hat, Inc.
+  ~ All rights reserved.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation version 2 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software Foundation, Inc.,
+  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+  -->
+
+<differences>
+  <difference>
+    <className>org/rhq/core/domain/resource/DeleteResourceHistory</className>
+    <differenceType>6011</differenceType> <!-- constant removed -->
+    <field>QUERY_DELETE_BY_RESOURCES</field>
+    <justification>BZ 1168890</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/domain/resource/DeleteResourceHistory</className>
+    <differenceType>7002</differenceType> <!-- method removed -->
+    <method>org.rhq.core.domain.resource.Resource getResource()</method>
+    <justification>BZ 1168890</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/domain/resource/DeleteResourceHistory</className>
+    <differenceType>7002</differenceType> <!-- method removed -->
+    <method>void setResource(org.rhq.core.domain.resource.Resource)</method>
+    <justification>BZ 1168890</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/domain/resource/Resource</className>
+    <differenceType>7002</differenceType> <!-- method removed -->
+    <method>void addDeleteResourceHistory(org.rhq.core.domain.resource.DeleteResourceHistory)</method>
+    <justification>BZ 1168890</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/domain/resource/Resource</className>
+    <differenceType>7002</differenceType> <!-- method removed -->
+    <method>java.util.List getDeleteResourceRequests()</method>
+    <justification>BZ 1168890</justification>
+  </difference>
+  <difference>
+    <className>org/rhq/core/domain/resource/Resource</className>
+    <differenceType>7002</differenceType> <!-- method removed -->
+    <method>void setDeleteResourceRequests(java.util.List)</method>
+    <justification>BZ 1168890</justification>
+  </difference>
+  
+</differences>
+

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/resource/InventoryStatus.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/resource/InventoryStatus.java
@@ -44,9 +44,8 @@ public enum InventoryStatus {
      *    <li>COMMITTED: Resources in this state will be visible in the inventory browser.  The act of importing
      *                   resources changes their state from NEW to COMMITTED.  Note: resources that are factory-created
      *                   or manually added will also appear in the inventory browser and, thus, will be COMMITTED.</li>
-     *                   
-     *    <li>DELETED: Resources can be removed from the remote box, which will flip their status to DELETED to suppress
-     *                 them from showing up in the inventory browser.</li>
+     *
+     *     <li>DELETED: This state is deprecated since RHQ 4.14 and exists only for API compatibility reason.</li>
      *                 
      *    <li>UNINVENTORIED: Resources can be removed from the inventory.  Since this is an expensive operation, these
      *                       resources are temporarily marked as UNINVENTORIED which will suppress them from showing up

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/resource/Resource.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/resource/Resource.java
@@ -1107,11 +1107,6 @@ public class Resource implements Comparable<Resource>, Serializable {
     // bulk delete @OneToMany(mappedBy = "resource", cascade = { CascadeType.ALL })
     @OneToMany(mappedBy = "resource", cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
     @OrderBy
-    private List<DeleteResourceHistory> deleteResourceRequests;//  = new ArrayList<DeleteResourceHistory>();
-
-    // bulk delete @OneToMany(mappedBy = "resource", cascade = { CascadeType.ALL })
-    @OneToMany(mappedBy = "resource", cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
-    @OrderBy
     // by primary key which will also put the operation histories in chronological order
     private List<ResourceOperationHistory> operationHistories;//  = new ArrayList<ResourceOperationHistory>();
 
@@ -1624,22 +1619,6 @@ public class Resource implements Comparable<Resource>, Serializable {
         }
         request.setParentResource(this);
         this.createChildResourceRequests.add(request);
-    }
-
-    public List<DeleteResourceHistory> getDeleteResourceRequests() {
-        if (deleteResourceRequests == null) {
-            deleteResourceRequests = new ArrayList<DeleteResourceHistory>(1);
-        }
-        return deleteResourceRequests;
-    }
-
-    public void setDeleteResourceRequests(List<DeleteResourceHistory> deleteResourceRequests) {
-        this.deleteResourceRequests = deleteResourceRequests;
-    }
-
-    public void addDeleteResourceHistory(DeleteResourceHistory history) {
-        history.setResource(this);
-        this.deleteResourceRequests.add(history);
     }
 
     public Agent getAgent() {

--- a/modules/core/plugin-container/src/main/java/org/rhq/core/pc/inventory/DeleteResourceRunner.java
+++ b/modules/core/plugin-container/src/main/java/org/rhq/core/pc/inventory/DeleteResourceRunner.java
@@ -22,17 +22,17 @@
   */
 package org.rhq.core.pc.inventory;
 
- import org.rhq.core.clientapi.agent.inventory.DeleteResourceResponse;
- import org.rhq.core.clientapi.server.inventory.ResourceFactoryServerService;
- import org.rhq.core.domain.resource.DeleteResourceStatus;
- import org.rhq.core.pc.PluginContainer;
- import org.rhq.core.pluginapi.inventory.DeleteResourceFacet;
- import org.rhq.core.util.exception.ThrowableUtil;
-
- import org.apache.commons.logging.Log;
- import org.apache.commons.logging.LogFactory;
-
  import java.util.concurrent.Callable;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.rhq.core.clientapi.agent.inventory.DeleteResourceResponse;
+import org.rhq.core.clientapi.server.inventory.ResourceFactoryServerService;
+import org.rhq.core.domain.resource.DeleteResourceStatus;
+import org.rhq.core.pc.PluginContainer;
+import org.rhq.core.pluginapi.inventory.DeleteResourceFacet;
+import org.rhq.core.util.exception.ThrowableUtil;
 
  /**
  * Runnable implementation to thread delete resource requests.
@@ -112,7 +112,7 @@ public class DeleteResourceRunner implements Callable, Runnable {
             status = DeleteResourceStatus.FAILURE;
         }
 
-        DeleteResourceResponse response = new DeleteResourceResponse(requestId, status, errorMessage);
+        DeleteResourceResponse response = new DeleteResourceResponse(requestId, resourceId, status, errorMessage);
 
         ResourceFactoryServerService serverService = resourceFactoryManager.getServerService();
         if (serverService != null) {

--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/inventory/resource/detail/ChildHistoryDetails.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/inventory/resource/detail/ChildHistoryDetails.java
@@ -190,17 +190,8 @@ public class ChildHistoryDetails extends EnhancedVLayout {
         StaticTextItem deletedResourceName = new StaticTextItem("deletedResourceName", MSG.common_title_resource_name());
         StaticTextItem deletedResourceType = new StaticTextItem("deletedResourceType", MSG.common_title_resource_type());
 
-        if (history.getResource() != null) {
-            deletedResourceName.setValue(history.getResource().getName());
-            if (history.getResource().getResourceType() != null) {
-                deletedResourceType.setValue(ResourceTypeUtility.displayName(history.getResource().getResourceType()));
-            } else {
-                deletedResourceType.setValue(MSG.common_status_unknown());
-            }
-        } else {
-            deletedResourceName.setValue(MSG.common_status_unknown());
-            deletedResourceType.setValue(MSG.common_status_unknown());
-        }
+        deletedResourceName.setValue(history.getResourceName());
+        deletedResourceType.setValue(ResourceTypeUtility.displayName(history.getResourceType()));
 
         TextAreaItem errorMessage = new TextAreaItem("errorMessage", MSG.common_severity_error());
         errorMessage.setValue(history.getErrorMessage());

--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/inventory/resource/discovery/AutodiscoveryQueueDataSource.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/inventory/resource/discovery/AutodiscoveryQueueDataSource.java
@@ -305,9 +305,6 @@ public class AutodiscoveryQueueDataSource extends DataSource {
             case IGNORED:
                 setAttribute("statusLabel", MSG.view_autoDiscoveryQ_ignored());
                 break;
-            case DELETED:
-                setAttribute("statusLabel", MSG.view_autoDiscoveryQ_deleted());
-                break;
             case UNINVENTORIED:
                 setAttribute("statusLabel", MSG.view_autoDiscoveryQ_uninventoried());
                 break;

--- a/modules/enterprise/server/itests-2/src/test/java/org/rhq/enterprise/server/resource/metadata/test/UpdatePluginMetadataTestBase.java
+++ b/modules/enterprise/server/itests-2/src/test/java/org/rhq/enterprise/server/resource/metadata/test/UpdatePluginMetadataTestBase.java
@@ -400,7 +400,6 @@ public class UpdatePluginMetadataTestBase extends AbstractEJB3Test {
                 c.addFilterResourceTypeId(rt.getId());
                 c.addFilterInventoryStatus(InventoryStatus.NEW);
                 List<Resource> doomedResources = resourceManager.findResourcesByCriteria(overlord, c);
-                c.addFilterInventoryStatus(InventoryStatus.DELETED);
                 doomedResources.addAll(resourceManager.findResourcesByCriteria(overlord, c));
                 c.addFilterInventoryStatus(InventoryStatus.UNINVENTORIED);
                 doomedResources.addAll(resourceManager.findResourcesByCriteria(overlord, c));

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossBean.java
@@ -904,13 +904,6 @@ public class DiscoveryBossBean implements DiscoveryBossLocal, DiscoveryBossRemot
             throw new InvalidInventoryReportException("Reported resource [" + resource + "] has a null key.");
         }
 
-        if (resource.getInventoryStatus() == InventoryStatus.DELETED) {
-            throw new InvalidInventoryReportException(
-                "Reported resource ["
-                    + resource
-                    + "] has an illegal inventory status of 'DELETED' - agents are not allowed to delete platforms from inventory.");
-        }
-
         // Recursively validate all the resource's descendants.
         for (Resource childResource : resource.getChildResources()) {
             validateResource(childResource);
@@ -1273,15 +1266,7 @@ public class DiscoveryBossBean implements DiscoveryBossLocal, DiscoveryBossRemot
             LOG.warn("Agent reported that key for " + existingResource + " has changed from '"
                 + existingResource.getResourceKey() + "' to '" + updatedResource.getResourceKey() + "'.");
         }
-
         updateResourceVersion(existingResource, updatedResource.getVersion());
-
-        // If the resource was marked as deleted, reactivate it again.
-        if (existingResource.getInventoryStatus() == InventoryStatus.DELETED) {
-            existingResource.setInventoryStatus(InventoryStatus.COMMITTED);
-            existingResource.setPluginConfiguration(updatedResource.getPluginConfiguration());
-            existingResource.setAgentSynchronizationNeeded();
-        }
     }
 
     private boolean initResourceTypes(Resource resource) {

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryServerServiceImpl.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryServerServiceImpl.java
@@ -236,7 +236,6 @@ public class DiscoveryServerServiceImpl implements DiscoveryServerService {
         resource.setAutoGroupBackingGroups(Collections.EMPTY_LIST);
         resource.setExplicitGroups(Collections.EMPTY_SET);
         resource.setCreateChildResourceRequests(Collections.EMPTY_LIST);
-        resource.setDeleteResourceRequests(Collections.EMPTY_LIST);
         resource.setImplicitGroups(Collections.EMPTY_SET);
         resource.setInstalledPackageHistory(Collections.EMPTY_LIST);
         resource.setInstalledPackages(Collections.EMPTY_SET);
@@ -327,8 +326,7 @@ public class DiscoveryServerServiceImpl implements DiscoveryServerService {
     }
 
     private static boolean isVisibleInInventory(Resource resource) {
-        return resource.getInventoryStatus() != InventoryStatus.DELETED
-            && resource.getInventoryStatus() != InventoryStatus.UNINVENTORIED;
+        return resource.getInventoryStatus() != InventoryStatus.UNINVENTORIED;
     }
 
     @Override

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/ResourceManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/ResourceManagerBean.java
@@ -737,7 +737,7 @@ public class ResourceManagerBean implements ResourceManagerLocal, ResourceManage
             ContentServiceRequest.QUERY_DELETE_BY_RESOURCES, //
             ResourceOperationScheduleEntity.QUERY_DELETE_BY_RESOURCES, //
             ResourceOperationHistory.QUERY_DELETE_BY_RESOURCES, //
-            DeleteResourceHistory.QUERY_DELETE_BY_RESOURCES, //
+            DeleteResourceHistory.QUERY_DELETE_BY_PARENT_RESOURCE_IDS, // delete history items where this resource was parent (it's children was deleted)
             CreateResourceHistory.QUERY_DELETE_BY_RESOURCES, //
             ResourceConfigurationUpdate.QUERY_DELETE_BY_RESOURCES_0, // orphan parent list or maps (execute only on non selfRefCascade dbs)
             ResourceConfigurationUpdate.QUERY_DELETE_BY_RESOURCES_1, // first, delete the raw configs for the config

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/metadata/ResourceMetadataManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/metadata/ResourceMetadataManagerBean.java
@@ -50,6 +50,7 @@ import org.rhq.core.domain.drift.DriftDefinition;
 import org.rhq.core.domain.drift.DriftDefinitionComparator;
 import org.rhq.core.domain.drift.DriftDefinitionComparator.CompareMode;
 import org.rhq.core.domain.drift.DriftDefinitionTemplate;
+import org.rhq.core.domain.resource.DeleteResourceHistory;
 import org.rhq.core.domain.resource.ProcessScan;
 import org.rhq.core.domain.resource.Resource;
 import org.rhq.core.domain.resource.ResourceType;
@@ -282,6 +283,16 @@ public class ResourceMetadataManagerBean implements ResourceMetadataManagerLocal
 
         measurementMetadataMgr.deleteMetadata(existingType);
         entityManager.flush();
+
+        // remove DeleteResourceHistories
+        try {
+            Query nativeQuery = entityManager.createNamedQuery(DeleteResourceHistory.QUERY_DELETE_BY_RESOURCE_TYPE_ID);
+            nativeQuery.setParameter("resourceTypeId", existingType.getId());
+            nativeQuery.executeUpdate();
+        } catch (Throwable t) {
+            throw new RuntimeException("DeleteResourceHistory deletion failed, . Cannot finish deleting "
+                + existingType, t);
+        }
 
         // TODO: Clean out event definitions?
 

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/ResourceHandlerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/ResourceHandlerBean.java
@@ -237,7 +237,7 @@ public class ResourceHandlerBean extends AbstractRestBean {
                                         @ApiParam("Limit to category (PLATFORM, SERVER, SERVICE") @QueryParam("category") String category,
                                         @ApiParam("Page size for paging") @QueryParam("ps") @DefaultValue("20") int pageSize,
                                         @ApiParam("Page for paging, 0-based") @QueryParam("page") @DefaultValue("0") Integer page,
-                                        @ApiParam(value = "Limit to Inventory status of the resources", allowableValues = "ALL, NEW, IGNORED, COMMITTED, DELETED, UNINVENTORIED")
+                                        @ApiParam(value = "Limit to Inventory status of the resources", allowableValues = "ALL, NEW, IGNORED, COMMITTED, UNINVENTORIED")
                                             @DefaultValue("COMMITTED") @QueryParam("status") String status,
                                         @Context HttpHeaders headers,
                                         @Context UriInfo uriInfo) {
@@ -248,7 +248,8 @@ public class ResourceHandlerBean extends AbstractRestBean {
             try {
                 criteria.addFilterInventoryStatus(InventoryStatus.valueOf(status.toUpperCase()));
             } catch (IllegalArgumentException iae) {
-                throw new BadArgumentException("status","Value " + status + " is not in the list of allowed values: ALL, NEW, IGNORED, COMMITTED, DELETED, UNINVENTORIED" );
+                throw new BadArgumentException("status", "Value " + status
+                    + " is not in the list of allowed values: ALL, NEW, IGNORED, COMMITTED, UNINVENTORIED");
             }
         } else {
             // JavaDoc says to explicitly set to null in order to get all Status

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/domain/ResourceWithType.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/domain/ResourceWithType.java
@@ -117,7 +117,7 @@ public class ResourceWithType {
         this.parentId = parentId;
     }
 
-    @ApiProperty(value = "Inventory status of the resource.",allowableValues = "NEW, IGNORED, COMMITTED, DELETED, UNINVENTORIED" )
+    @ApiProperty(value = "Inventory status of the resource.", allowableValues = "NEW, IGNORED, COMMITTED, UNINVENTORIED")
     public String getStatus() {
         return status;
     }


### PR DESCRIPTION
DELETED InventoryStatus removed, this has a consequence in
DeleteResourceHistory, which now refers to parent resource and if successull
(meaning resource has been deleted) it's resource is set to NULL. To be able
to present in UI "what was deleted" 2 more columns have been added (resource
name, resource type name).

This commit causes signature-check to fail, this is intentional at this
point to get feedback and also this commit will likely not end up in 4.13 -
api-check xml can be added post 4.13
