### PR TITLE
Bug 1173096 - Support for Filtering child resources

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/ResourceHandlerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/ResourceHandlerBean.java
@@ -556,14 +556,41 @@ public class ResourceHandlerBean extends AbstractRestBean {
             @ApiParam("Id of the resource to get children") @PathParam("id") int id,
             @ApiParam("Page size for paging") @QueryParam("ps") @DefaultValue("20") int pageSize,
             @ApiParam("Page for paging, 0-based") @QueryParam("page") @DefaultValue("0") Integer page,
+            @ApiParam("Limit results to param in the resource name") @QueryParam("q") String q,
+            @ApiParam("Limit to category (PLATFORM, SERVER, SERVICE)") @QueryParam("category") String category,
+            @ApiParam(value = "Limit to Inventory status of the resources", allowableValues = "ALL, NEW, IGNORED, COMMITTED, DELETED, UNINVENTORIED")
+                @DefaultValue("COMMITTED") @QueryParam("status") String status,
             @Context HttpHeaders headers,
             @Context UriInfo uriInfo) {
 
-        PageControl pc = new PageControl(page,pageSize);
-        Resource parent;
-        parent = fetchResource(id);
-        List<Resource> ret = resMgr.findResourceByParentAndInventoryStatus(caller, parent, InventoryStatus.COMMITTED,
-            pc);
+        // just check if resource exists
+        fetchResource(id);
+
+        ResourceCriteria criteria = new ResourceCriteria();
+        criteria.addSortName(PageOrdering.ASC);
+        criteria.addFilterParentResourceId(id);
+        if (!status.toLowerCase().equals("all")) {
+            try {
+                criteria.addFilterInventoryStatus(InventoryStatus.valueOf(status.toUpperCase()));
+            } catch (IllegalArgumentException iae) {
+                throw new BadArgumentException("status", "Value " + status
+                    + " is not in the list of allowed values: ALL, NEW, IGNORED, COMMITTED, DELETED, UNINVENTORIED");
+            }
+        } else {
+            // JavaDoc says to explicitly set to null in order to get all Status
+            criteria.addFilterInventoryStatus(null);
+        }
+        if (q != null) {
+            criteria.addFilterName(q);
+        }
+        if (category != null) {
+            criteria.addFilterResourceCategories(ResourceCategory.valueOf(category.toUpperCase()));
+        }
+        if (page != null) {
+            criteria.setPaging(page, pageSize);
+        }
+        PageList<Resource> ret = resMgr.findResourcesByCriteria(caller, criteria);
+
         List<ResourceWithType> rwtList = new ArrayList<ResourceWithType>(ret.size());
         for (Resource r : ret) {
             ResourceWithType rwt = fillRWT(r, uriInfo);

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/helper/ResourceCriteriaHelper.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/helper/ResourceCriteriaHelper.java
@@ -1,0 +1,184 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2014 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation, and/or the GNU Lesser
+ * General Public License, version 2.1, also as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.rhq.enterprise.server.rest.helper;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.rhq.core.domain.criteria.ResourceCriteria;
+import org.rhq.core.domain.measurement.AvailabilityType;
+import org.rhq.core.domain.resource.InventoryStatus;
+import org.rhq.core.domain.resource.ResourceCategory;
+import org.rhq.enterprise.server.rest.BadArgumentException;
+
+/**
+ * this helper class builds {@link ResourceCriteria based on query parameters map}
+ * @author lzoubek
+ *
+ */
+public class ResourceCriteriaHelper {
+
+    /**
+     * special parameters are either ignored or handled specialy
+     */
+    private static final List<String> SPECIAL_PARAMS = Arrays.asList("page", "ps", "strict");
+
+    /**
+     * mapping param shortcutName to param full name (this map gets filled in class constructor)
+     */
+    private static final Map<String, String> PARAM_SHORTCUTS = new LinkedHashMap<String, String>();
+
+    /**
+     * we store parameter name shortcuts as text for API documentation purposes
+     */
+    public static final String PARAM_SHORTCUTS_TEXT = "status=inventoryStatus, availability=currentAvailability, category=resourceCategories, plugin=pluginName, parentId=parentResourceId, parentName=parentResourceName, type=resourceTypeName";
+    static {
+        String[] pairs = PARAM_SHORTCUTS_TEXT.split(", ");
+        for (int i = 0; i < pairs.length; i++) {
+            String[] pair = pairs[i].split("=");
+            PARAM_SHORTCUTS.put(pair[0], pair[1]);
+        }
+    }
+
+    /**
+     * creates new criteria instance based on given params. Currently we support single value addFilterXXX functions, and strict parameter. Paging is ignored.
+     * @param params query parameters
+     * @return resource criteria
+     */
+    public static ResourceCriteria create(MultivaluedMap<String,String> params) {
+        ResourceCriteria criteria = new ResourceCriteria();
+        criteria.clearPaging();
+        Method[] methods = ResourceCriteria.class.getMethods();
+        for (Entry<String, List<String>> e : params.entrySet()) {
+            String value = params.getFirst(e.getKey());
+            if (value == null) {
+                continue;
+            }
+            String paramName = paramName(e.getKey());
+            if (SPECIAL_PARAMS.contains(e.getKey())) {
+                try {
+                    handleSpecialParam(criteria, e.getKey(), value);
+                } catch (Exception ex) {
+                    throw new BadArgumentException("Unable to parse [" + e.getKey() + "] value [" + value
+                        + "] is not valid");
+                }
+            } else {
+                String filterName = "addFilter" + paramName.substring(0, 1).toUpperCase() + paramName.substring(1);
+                Method m = findMethod(methods, filterName);
+                if (m != null) {
+                    try {
+                        m.invoke(criteria, getValue(m, paramName, value));
+                    } catch (BadArgumentException bae) {
+                        throw bae;
+                    } catch (Exception ex) {
+                        throw new BadArgumentException("Unable to filter by [" + paramName + "] value [" + value
+                            + "] is not valid for this filter");
+                    }
+
+                } else {
+                    throw new BadArgumentException("Unable to filter by [" + paramName + "] : filter does not exist");
+                }
+            }
+
+        }
+        return criteria;
+    }
+
+    private static String paramName(String name) {
+        String newName = PARAM_SHORTCUTS.get(name);
+        return newName == null ? name : newName;
+    }
+
+    private static void handleSpecialParam(ResourceCriteria criteria, String filter, String value) {
+        if ("strict".equals(filter)) {
+            criteria.setStrict(Boolean.parseBoolean(value));
+            return;
+        }
+        // skip ps and page .. we ignore those
+    }
+
+    private static Object getValue(Method m, String filter, String value) {
+        Class<?> parameterType = m.getParameterTypes()[0];
+        if (parameterType.isArray()) {
+            parameterType = parameterType.getComponentType();
+        }
+        if (parameterType.isEnum()) {
+            return enumParamValue(filter, value);
+        }
+        if (parameterType.isAssignableFrom(Integer.class)
+            || (parameterType.isPrimitive() && "int".equals(parameterType.getName()))) {
+            return Integer.parseInt(value);
+        }
+        if (parameterType.isAssignableFrom(Long.class)
+            || (parameterType.isPrimitive() && "long".equals(parameterType.getName()))) {
+            return Long.parseLong(value);
+        }
+
+        return value;
+    }
+
+    private static Object enumParamValue(String filter, String value) {
+        if ("inventoryStatus".equals(filter)) {
+            try {
+                return InventoryStatus.valueOf(value.toUpperCase());
+            } catch (Exception ex) {
+                throw new BadArgumentException(filter, "Value " + value + " is not in the list of allowed values: "
+                    + Arrays.toString(InventoryStatus.values()));
+            }
+
+        }
+        if ("currentAvailability".equals(filter)) {
+            try {
+                return AvailabilityType.valueOf(value.toUpperCase());
+            } catch (Exception ex) {
+                throw new BadArgumentException(filter, "Value " + value + " is not in the list of allowed values: "
+                    + Arrays.toString(AvailabilityType.values()));
+            }
+        }
+        if ("resourceCategories".equals(filter)) {
+            try {
+                return new ResourceCategory[] { ResourceCategory.valueOf(value.toUpperCase()) };
+            } catch (Exception ex) {
+                throw new BadArgumentException(filter, "Value " + value + " is not in the list of allowed values: "
+                    + Arrays.toString(ResourceCategory.values()));
+            }
+        }
+        return null;
+
+    }
+
+    private static Method findMethod(Method[] methods, String name) {
+        for (Method m : methods) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        return null;
+    }
+}

--- a/modules/enterprise/server/jar/src/test/java/org/rhq/enterprise/server/rest/helper/ResourceCriteriaHelperTest.java
+++ b/modules/enterprise/server/jar/src/test/java/org/rhq/enterprise/server/rest/helper/ResourceCriteriaHelperTest.java
@@ -1,0 +1,104 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2014 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation, and/or the GNU Lesser
+ * General Public License, version 2.1, also as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.rhq.enterprise.server.rest.helper;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.testng.annotations.Test;
+
+import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
+
+import org.rhq.core.domain.resource.ResourceCategory;
+import org.rhq.enterprise.server.rest.BadArgumentException;
+
+@Test
+public class ResourceCriteriaHelperTest {
+
+    @Test(expectedExceptions = { BadArgumentException.class }, expectedExceptionsMessageRegExp = ".*does not exist.*")
+    public void testInvalidParam() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("foo", "bar");
+        ResourceCriteriaHelper.create(params);
+    }
+
+    @Test(expectedExceptions = { BadArgumentException.class }, expectedExceptionsMessageRegExp = ".*inventoryStatus is bad.*")
+    public void testEnumParamInvalidValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("inventoryStatus", "FOO");
+        ResourceCriteriaHelper.create(params);
+    }
+
+    @Test(expectedExceptions = { BadArgumentException.class }, expectedExceptionsMessageRegExp = ".*is not valid.*")
+    public void testNumericParamInvalidValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("id", "FOO");
+        ResourceCriteriaHelper.create(params);
+    }
+
+    public void testSpecialParamValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("strict", "FOO");
+        assert ResourceCriteriaHelper.create(params).isStrict() == false;
+        params.clear();
+        params.putSingle("strict", "true");
+        assert ResourceCriteriaHelper.create(params).isStrict() == true;
+    }
+
+    public void testNumericParamValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("id", "1234");
+        params.putSingle("startItime", "2");
+        assert ResourceCriteriaHelper.create(params) != null;
+    }
+
+    public void testEnumParamValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("inventoryStatus", "NEW");
+        assert ResourceCriteriaHelper.create(params) != null;
+    }
+
+    public void testStringParamValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("name", "1234");
+        assert ResourceCriteriaHelper.create(params) != null;
+    }
+
+    public void testStringParamWithoutValue() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.put("name", null);
+        assert ResourceCriteriaHelper.create(params) != null;
+    }
+
+    public void testParamShortcuts() {
+        MultivaluedMap<String, String> params = new MultivaluedMapImpl<String, String>();
+        params.putSingle("status", "NEW");
+        params.putSingle("availability", "up");
+        params.putSingle("type", "FOO");
+        params.putSingle("category", ResourceCategory.SERVER.getName());
+        params.putSingle("plugin", "FOO");
+        params.putSingle("type", "FOO");
+        params.putSingle("parentName", "FOO");
+        params.putSingle("parentId", "1");
+        assert ResourceCriteriaHelper.create(params) != null;
+    }
+}

--- a/modules/integration-tests/rest-api/src/test/java/org/rhq/modules/integrationTests/restApi/ResourcesTest.java
+++ b/modules/integration-tests/rest-api/src/test/java/org/rhq/modules/integrationTests/restApi/ResourcesTest.java
@@ -54,6 +54,7 @@ import com.jayway.restassured.response.Headers;
 import com.jayway.restassured.response.Response;
 
 import org.apache.http.HttpStatus;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.rhq.modules.integrationTests.restApi.d.Availability;
@@ -294,6 +295,35 @@ public class ResourcesTest extends AbstractBase {
             .get("/resource/" + _platformId + "/children");
         JsonPath jsonPath = r.jsonPath();
         assert jsonPath.getList("").size() == 2;
+    }
+
+    @Test
+    public void testGetChildResourcesWithFilter() throws Exception {
+
+        int platform = findIdOfARealPlatform();
+        Response r = given()
+            .header("Accept", "application/json")
+        .with()
+            .queryParam("category", "platform")
+        .expect()
+            .statusCode(200)
+            .log().everything()
+        .when()
+            .get("/resource/" + _platformId + "/children");
+        assert r.jsonPath().getList("").size() == 0;
+
+        r = given()
+            .header("Accept", "application/json")
+        .with()
+            .queryParam("q", "Storage")
+        .expect()
+            .statusCode(200)
+            .log().everything()
+        .when()
+            .get("/resource/" + platform + "/children");
+
+        Assert.assertTrue(r.getBody().asString() + "", r
+            .jsonPath().getList("").size() == 1);
     }
 
     @Test


### PR DESCRIPTION
First commit adds:
/resource/{id}/children that could accept the same @QueryParams as /resource
- child resources can now be filtered by name status and category

2nd commit adds:
Added new endpoint : GET /resource/search which supports *ALL* filtering
options from ResourceCriteria class with small exception - it cannot pass
multiple values to filter functions.

2nd commit implementation has an advantage of being generic (if we happen to add a filter to ResourceCriteria, there is a fair chance we don't have to touch REST code, but also a disadvantage - documentation - every parameter could not be documented. I'd like to ask for review .. wheter we want to go this way. We may merge only first commit, but I think the 2nd one adds a real power to REST API to resource filtering
