### PR TITLE
[1174841] UnsupportedOperationException on mergeInventoryReport()

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/discovery/DiscoveryBossBean.java
@@ -1314,11 +1314,18 @@ public class DiscoveryBossBean implements DiscoveryBossLocal, DiscoveryBossRemot
             return true;
         }
 
+        // bz1174841 protect against the case where resource.hasCustomChildResourcesCollection() is true and the
+        // custom collection does not support Iterator.remove(). (note, just uses an approach that works in all cases.)
+        Set<Resource> badChildren = null;
         for (Iterator<Resource> childIterator = resource.getChildResources().iterator(); childIterator.hasNext();) {
             Resource child = childIterator.next();
             if (!initResourceTypes(child, loadedTypeMap)) {
-                childIterator.remove();
+                badChildren = (null == badChildren) ? new HashSet<Resource>() : badChildren;
+                badChildren.add(child);
             }
+        }
+        if (null != badChildren) {
+            resource.getChildResources().removeAll(badChildren);
         }
 
         return true;


### PR DESCRIPTION
Avoid the use of Iterator.remove() because Resources coming from the
Agent may be using a customized impl for Resource.childResources (like
CopyOnWriteArraySet).  The solution "lazily protects" because the
problem scenario is rare (restype reported by agent is not
present on the server) and we don't want to do any unnecessary work (like
changing the Set impl in advance).
