### PR TITLE
[BZ 1175774] - Make JBoss ON code base buildable with jdk 8

### DIFF
--- a/modules/core/domain/pom.xml
+++ b/modules/core/domain/pom.xml
@@ -131,8 +131,8 @@
       <!-- NOTE: The remaining test deps correspond to the classes contained in hibernate-all.jar and thirdparty-all.jar. -->
 
       <dependency>
-         <groupId>antlr</groupId>
-         <artifactId>antlr</artifactId>
+         <groupId>org.antlr</groupId>
+         <artifactId>antlr-complete</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/modules/enterprise/remoting/client-deps/pom.xml
+++ b/modules/enterprise/remoting/client-deps/pom.xml
@@ -36,6 +36,10 @@
              <artifactId>antlr</artifactId>
            </exclusion>
            <exclusion>
+             <groupId>org.antlr</groupId>
+             <artifactId>antlr-complete</artifactId>
+           </exclusion>
+           <exclusion>
              <groupId>com.jcraft</groupId>
              <artifactId>jsch</artifactId>
            </exclusion>

--- a/modules/enterprise/server/jar/pom.xml
+++ b/modules/enterprise/server/jar/pom.xml
@@ -217,27 +217,9 @@
     </dependency>
 
     <!-- 3rd Party Deps -->
-
-    <!-- do we really need this version, for now use the version provided by AS7, declare just below -->
     <dependency>
       <groupId>org.antlr</groupId>
-      <artifactId>antlr-runtime</artifactId>
-      <version>3.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>antlr</groupId>
-          <artifactId>antlr</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.antlr</groupId>
-          <artifactId>antlr</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>antlr</groupId>
-      <artifactId>antlr</artifactId>
+      <artifactId>antlr-complete</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/modules/helpers/inventory-serializer/pom.xml
+++ b/modules/helpers/inventory-serializer/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
-            <version>3.3</version>
+            <version>${antlr.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/modules/plugins/jmx/pom.xml
+++ b/modules/plugins/jmx/pom.xml
@@ -116,7 +116,7 @@
          <id>integration-tests</id>
          <activation>
             <property>
-               <name>maven.test.skip</name>
+               <name>skipTests</name>
                <value>!true</value>
             </property>
          </activation>

--- a/modules/plugins/mod-cluster/pom.xml
+++ b/modules/plugins/mod-cluster/pom.xml
@@ -32,6 +32,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.integration</groupId>
+        <artifactId>jboss-profileservice-spi</artifactId>
+        <version>6.0.0.Alpha9</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.on</groupId>
          <artifactId>jopr-jboss-as-plugin</artifactId>
          <version>${project.version}</version>
@@ -47,7 +54,6 @@
 
    <build>
       <plugins>
-
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <animal.sniffer.version>1.8</animal.sniffer.version>
     <annotations.version>7.0.2</annotations.version>
     <ant.contrib.version>1.0b3</ant.contrib.version>
-    <antlr.version>2.7.7</antlr.version>
+    <antlr.version>3.5.2</antlr.version>
     <apache.httpcomponents.version>4.2.5</apache.httpcomponents.version>
     <arquillian.version>1.0.4.Final</arquillian.version> <!-- as of 6/25/2014 the latest version publically available is 1.1.4.Final, but we can't compile with that yet -->
     <arquillian.jboss.container.version>7.2.0.Final</arquillian.jboss.container.version> <!-- as of 6/25/2014 this is the latest version publically available -->
@@ -781,8 +781,8 @@
       </dependency>
 
       <dependency>
-         <groupId>antlr</groupId>
-         <artifactId>antlr</artifactId>
+         <groupId>org.antlr</groupId>
+         <artifactId>antlr-complete</artifactId>
          <version>${antlr.version}</version>
       </dependency>
 
@@ -1380,6 +1380,10 @@
          <plugin>
            <artifactId>maven-javadoc-plugin</artifactId>
            <version>2.8</version>
+           <configuration>
+             <!-- this is needed by jdk 8 not to fail the build because of jdoc issues -->
+             <additionalparam>-Xdoclint:none</additionalparam>
+           </configuration>
          </plugin>
          <plugin>
            <artifactId>maven-plugin-plugin</artifactId>
@@ -1461,6 +1465,14 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>animal-sniffer-maven-plugin</artifactId>
             <version>${animal.sniffer.version}</version>
+            <dependencies>
+               <!-- Upgrade ASM and support Java 8 bytecode -->
+               <dependency>
+                  <groupId>org.ow2.asm</groupId>
+                  <artifactId>asm-all</artifactId>
+                  <version>5.0.3</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
@@ -1515,7 +1527,7 @@
          <plugin>
            <groupId>org.antlr</groupId>
            <artifactId>antlr3-maven-plugin</artifactId>
-           <version>3.2</version>
+           <version>${antlr.version}</version>
          </plugin>
        </plugins>
      </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1382,7 +1382,7 @@
            <version>2.8</version>
            <configuration>
              <!-- this is needed by jdk 8 not to fail the build because of jdoc issues -->
-             <additionalparam>-Xdoclint:none</additionalparam>
+             <additionalparam>${javadoc.doclint.none}</additionalparam>
            </configuration>
          </plugin>
          <plugin>
@@ -2435,8 +2435,16 @@
         </plugins>
      </reporting>
    </profile>
-</profiles>
-
+   <profile>
+      <id>java8-disable-strict-javadoc</id>
+      <activation>
+         <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+         <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
+      </properties>
+   </profile>
+  </profiles>
 
     <reporting>
         <plugins>


### PR DESCRIPTION
Talking Maven to build with Java 8

Here are things that caused build to failed:

* very strict javadoc checker
* animal sniffer, I used this workaround (https://jira.codehaus.org/browse/MANIMALSNIFFER-45) once the bug is solved we may upgrade the animal sniffer
* jmx plugin was starting AS and failing
* ANTLR issue (https://github.com/antlr/antlr3/issues/151) -> upgrading the ANTLR version
* mod_cluster plugin required the dependency on 'jboss-profileservice-spi' (scope = provided)

Before merging, I need to smoke test it and ensure it is still buildable/runnable on jdk6 and jdk7.
