### PR TITLE
[BZ 1147098] Queue all the numeric data before writing to the StorageNode

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/measurement/MeasurementDataManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/measurement/MeasurementDataManagerBean.java
@@ -52,6 +52,7 @@ import javax.persistence.Query;
 import javax.sql.DataSource;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.util.concurrent.FutureCallback;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -216,35 +217,26 @@ public class MeasurementDataManagerBean implements MeasurementDataManagerLocal, 
         }
 
         MetricsServer metricsServer = storageClientManager.getMetricsServer();
-        metricsServer.addNumericData(data, new RawDataInsertedCallback() {
-
-            private ReentrantLock lock = new ReentrantLock();
-
-            private Set<MeasurementData> insertedData = new TreeSet<MeasurementData>(new Comparator<MeasurementData>() {
-                @Override
-                public int compare(MeasurementData d1, MeasurementData d2) {
-                    return (d1.getTimestamp() < d2.getTimestamp()) ? -1 : ((d1.getTimestamp() == d2.getTimestamp()) ? 0 : 1);
-                }
-            });
+        metricsServer.addNumericData(data, new FutureCallback<Void>() {
 
             @Override
-            public void onFinish() {
+            public void onSuccess(@Nullable Void result) {
+                Set<MeasurementData> insertedData = new TreeSet<MeasurementData>(new Comparator<MeasurementData>() {
+                    @Override
+                    public int compare(MeasurementData d1, MeasurementData d2) {
+                        return (d1.getTimestamp() < d2.getTimestamp()) ? -1 : ((d1.getTimestamp() == d2.getTimestamp()) ? 0 : 1);
+                    }
+                });
+
+                insertedData.addAll(data);
                 measurementDataManager.updateAlertConditionCache("mergeMeasurementReport",
-                    insertedData.toArray(new MeasurementData[insertedData.size()]));
-            }
-
-            @Override
-            public void onSuccess(MeasurementDataNumeric measurementDataNumeric) {
-                try {
-                    lock.lock();
-                    insertedData.add(measurementDataNumeric);
-                }  finally {
-                    lock.unlock();
-                }
+                        insertedData.toArray(new MeasurementData[insertedData.size()]));
             }
 
             @Override
             public void onFailure(Throwable throwable) {
+                // This should cause rollback and agent to resubmit the raw data
+                throw new MeasurementStorageException(throwable);
             }
         });
     }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/storage/StorageClientManager.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/storage/StorageClientManager.java
@@ -626,4 +626,9 @@ public class StorageClientManager implements StorageClientManagerMBean{
         return driverMetrics.getRequestsTimer().mean();
     }
 
+    @Override
+    public int getQueueAvailableCapacity() {
+        return metricsServer.getQueueAvailableCapacity();
+    }
+
 }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/storage/StorageClientManagerMBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/storage/StorageClientManagerMBean.java
@@ -62,4 +62,8 @@ public interface StorageClientManagerMBean {
     double getFifteenMinuteAvgRate();
     double getMeanRate();
     double getMeanLatency();
+
+    // Queue
+
+    int getQueueAvailableCapacity();
 }

--- a/modules/enterprise/server/server-metrics/src/main/java/org/rhq/server/metrics/RawDataInsertedCallback.java
+++ b/modules/enterprise/server/server-metrics/src/main/java/org/rhq/server/metrics/RawDataInsertedCallback.java
@@ -32,7 +32,7 @@ import org.rhq.core.domain.measurement.MeasurementDataNumeric;
 /**
  * @author John Sanda
  */
-public interface RawDataInsertedCallback extends FutureCallback<MeasurementDataNumeric> {
+public interface RawDataInsertedCallback extends FutureCallback<Void> {
 
     void onFinish();
 

--- a/modules/enterprise/server/server-metrics/src/test/java/org/rhq/server/metrics/TimeoutTest.java
+++ b/modules/enterprise/server/server-metrics/src/test/java/org/rhq/server/metrics/TimeoutTest.java
@@ -81,41 +81,4 @@ public class TimeoutTest extends CassandraIntegrationTest {
 
         log.info("Inserted " + data1.size() + " raw metrics in " + (end - start) + " ms");
     }
-
-    private static class WaitForRawInserts implements RawDataInsertedCallback {
-
-        private final Log log = LogFactory.getLog(WaitForRawInserts.class);
-
-        private CountDownLatch latch;
-
-        private Throwable throwable;
-
-        public WaitForRawInserts(int numInserts) {
-            latch = new CountDownLatch(numInserts);
-        }
-
-        @Override
-        public void onFinish() {
-        }
-
-        @Override
-        public void onSuccess(MeasurementDataNumeric measurementDataNumeric) {
-            latch.countDown();
-        }
-
-        @Override
-        public void onFailure(Throwable throwable) {
-            latch.countDown();
-            this.throwable = throwable;
-            log.error("An async operation failed", throwable);
-        }
-
-        public void await(String errorMsg) throws InterruptedException {
-            latch.await();
-            if (throwable != null) {
-                fail(errorMsg, Throwables.getRootCause(throwable));
-            }
-        }
-    }
-
 }

--- a/modules/enterprise/server/server-metrics/src/test/java/org/rhq/server/metrics/WaitForRawInserts.java
+++ b/modules/enterprise/server/server-metrics/src/test/java/org/rhq/server/metrics/WaitForRawInserts.java
@@ -10,8 +10,6 @@ import com.google.common.base.Throwables;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.rhq.core.domain.measurement.MeasurementDataNumeric;
-
 /**
 * @author John Sanda
 */
@@ -28,11 +26,7 @@ class WaitForRawInserts implements RawDataInsertedCallback {
     }
 
     @Override
-    public void onFinish() {
-    }
-
-    @Override
-    public void onSuccess(MeasurementDataNumeric measurementDataNumeric) {
+    public void onSuccess(Void avoid) {
         latch.countDown();
     }
 
@@ -48,5 +42,10 @@ class WaitForRawInserts implements RawDataInsertedCallback {
         if (throwable != null) {
             fail(errorMsg, Throwables.getRootCause(throwable));
         }
+    }
+
+    @Override
+    public void onFinish() {
+
     }
 }

--- a/modules/helpers/metrics-simulator/src/main/java/org/rhq/metrics/simulator/MeasurementCollector.java
+++ b/modules/helpers/metrics-simulator/src/main/java/org/rhq/metrics/simulator/MeasurementCollector.java
@@ -92,7 +92,7 @@ public class MeasurementCollector implements Runnable {
             }
 
             @Override
-            public void onSuccess(MeasurementDataNumeric result) {
+            public void onSuccess(Void avoid) {
                 metrics.rawInserts.mark();
             }
 

--- a/modules/helpers/metrics-simulator/src/main/java/org/rhq/metrics/simulator/WaitForRawInserts.java
+++ b/modules/helpers/metrics-simulator/src/main/java/org/rhq/metrics/simulator/WaitForRawInserts.java
@@ -47,7 +47,7 @@ class WaitForRawInserts implements RawDataInsertedCallback {
     }
 
     @Override
-    public void onSuccess(MeasurementDataNumeric measurementDataNumeric) {
+    public void onSuccess(Void aVoid) {
         latch.countDown();
     }
 

--- a/modules/plugins/rhq-server/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/rhq-server/src/main/resources/META-INF/rhq-plugin.xml
@@ -443,6 +443,8 @@
 
     <metric property="CurrentWarmupTime" measurementType="dynamic" displayType="summary" description="Current throttling warmup period time in minutes." />
 
+    <metric property="QueueAvailableCapacity" measurementType="dynamic" displayType="summary" description="Length of the internal metric queue" />
+
     <resource-configuration>
       <c:simple-property name="RequestLimit" type="double" required="false" description="Sets throttling in terms of
                          requests per second. Defaults to 30,000 if undefined. Note that this setting is automatically


### PR DESCRIPTION
This patch accepts data from the agents if it can write it to the in-memory queue. Otherwise the agent receives an exception and it should resend the data on later time. This is to balance the load on the RHQ Server if the storage node is incapable of accepting configured amounts of writes per second. It also tries to prevent a loss of data by returning it back to the agent for later processing.
