### PR TITLE
Bug 1220277 - Correctly handle unsufficient permission errors

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseComponent.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseComponent.java
@@ -76,6 +76,7 @@ import org.rhq.modules.plugins.jbossas7.json.ResolveExpression;
 import org.rhq.modules.plugins.jbossas7.json.Result;
 import org.rhq.modules.plugins.jbossas7.json.ResultFailedException;
 import org.rhq.modules.plugins.jbossas7.json.SecurityRealmNotReadyException;
+import org.rhq.modules.plugins.jbossas7.json.UnauthorizedException;
 
 /**
  * The base class for all AS7 resource components.
@@ -818,6 +819,10 @@ public class BaseComponent<T extends ResourceComponent<?>> implements AS7Compone
             if (res.isTimedout()) {
                 throw new TimeoutException("Read attribute operation timed out");
             }
+            if (res.isRolledBack() && res.getFailureDescription().startsWith("JBAS013456")) {
+                throw new UnauthorizedException("Failed to read attribute [" + name + "] of address ["
+                    + getAddress().getPath() + "] - response: " + res);
+            }
             if (res.isRolledBack() && !res.getFailureDescription().startsWith("JBAS015135")) {
                 // this means we've connected, authenticated, but still failed
                 throw new ResultFailedException("Failed to read attribute [" + name + "] of address ["
@@ -828,6 +833,7 @@ public class BaseComponent<T extends ResourceComponent<?>> implements AS7Compone
                 throw new SecurityRealmNotReadyException("Failed to read attribute [" + name + "] of address ["
                     + getAddress().getPath() + "] - response: " + res);
             }
+
             throw new Exception("Failed to read attribute [" + name + "] of address [" + getAddress().getPath()
                 + "] - response: " + res);
         }

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/json/UnauthorizedException.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/json/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package org.rhq.modules.plugins.jbossas7.json;
+
+public class UnauthorizedException extends Exception {
+
+    /**
+     * "JBAS013456: Unauthorized to execute operation '...' for resource '...' -- \"JBAS013475: Permission denied\"
+     */
+    private static final long serialVersionUID = 1L;
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
This fixed BaseServerComponent only - so we display correct resource error,
when insufficient permissions are detected. In all other cases (create
child, operations) it should be obvious from EAP's response which appears on
top of stacktrace. This commit also fixes an issue when there are invalid
user/pass set in pluginConfiguration resource error was not reported
(because InvalidPluginConfigurationException thrown by AS7Connection.execute
was swallowed by getAvailability() code.