### PR TITLE
Bug 1173164 - Globally uncaught Exception shown in the JBoss ON UI when

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/operation/GroupOperationJob.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/operation/GroupOperationJob.java
@@ -99,6 +99,9 @@ public class GroupOperationJob extends OperationJob {
             // thus it's safe to pass in the overlord here
             schedule = operationManager.getGroupOperationSchedule(LookupUtil.getSubjectManager().getOverlord(),
                 jobDetail);
+            if (schedule == null) {
+                throw new CancelJobException("Resource Schedule no longer exists, canceling job");
+            }
 
             // create a new session even if user is logged in elsewhere, we don't want to attach to that user's session
             user = getUserWithSession(schedule.getSubject(), false);

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/operation/ResourceOperationJob.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/operation/ResourceOperationJob.java
@@ -88,6 +88,9 @@ public class ResourceOperationJob extends OperationJob {
 
             // retrieve the stored schedule using the overlord so it succeeds no matter what
             schedule = operationManager.getResourceOperationSchedule(getOverlord(), jobDetail);
+            if (schedule == null) {
+                throw new CancelJobException("Resource Schedule no longer exists, canceling job");
+            }
 
             // Login the schedule's subject so its assigned a session, so our security tests pass.
             // Create a new session even if user is logged in elsewhere, we don't want to attach to that user's session


### PR DESCRIPTION
trying to display orphaned operation schedule

Fixed by removing operation schedules (and unscheduling it) when the user
does not exist anymore. This removal does not happen at the time when user
is deleted, it happens when either - user want's to see such schedule (which
refers to missing user) or when scheduled job is about to run (in this case
it is canceled).