### PR TITLE
Bug 1236631 - Add a way to setup SSL settings in jboss-cli.xml

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseServerComponent.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseServerComponent.java
@@ -69,6 +69,7 @@ import org.rhq.core.util.StringUtil;
 import org.rhq.core.util.file.FileUtil;
 import org.rhq.modules.plugins.jbossas7.helper.HostConfiguration;
 import org.rhq.modules.plugins.jbossas7.helper.HostPort;
+import org.rhq.modules.plugins.jbossas7.helper.JBossCliConfiguration;
 import org.rhq.modules.plugins.jbossas7.helper.ServerPluginConfiguration;
 import org.rhq.modules.plugins.jbossas7.json.Address;
 import org.rhq.modules.plugins.jbossas7.json.ComplexResult;
@@ -447,6 +448,50 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
         context.getAvailabilityContext().requestAvailabilityCheck();
 
         return operationResult;
+    }
+
+    protected OperationResult setupCli(Configuration parameters) {
+        OperationResult result = new OperationResult();
+        ServerPluginConfiguration serverConfig = getServerPluginConfiguration();
+        File jbossCliXml = new File(new File(serverConfig.getHomeDir(), "bin"), "jboss-cli.xml");
+        try {
+            JBossCliConfiguration config = new JBossCliConfiguration(jbossCliXml, serverConfig);
+            StringBuilder response = new StringBuilder();
+            boolean madeChanges = false;
+            if (Boolean.parseBoolean(parameters.getSimpleValue("defaultController", "false"))) {
+                String m = config.configureDefaultController();
+                madeChanges |= m == null;
+                response.append(m == null ? "Setting up Default Controller" : "Default Controller skipped : " + m);
+                response.append("\n");
+            }
+            if (Boolean.parseBoolean(parameters.getSimpleValue("security", "false"))) {
+                String storeMethod = parameters.getSimpleValue("storePasswordMethod", "PLAIN");
+                String m = null;
+                String message = "Setting up Security";
+                if ("PLAIN".equals(storeMethod)) {
+                    message += " (using plain text)";
+                    m = config.configureSecurity();
+                } else {
+                    message += " (using vault)";
+                    m = config.configureSecurityUsingVault(getHostConfig());
+                }
+                madeChanges |= m == null;
+                response.append(m == null ? message : "Security skipped: " + m);
+                response.append("\n");
+            }
+
+            if (madeChanges) {
+                config.writeToFile();
+                response.append("Wrote changes to " + jbossCliXml);
+                result.setSimpleResult(response.toString());
+            } else {
+                result.setSimpleResult(jbossCliXml + " was not updated");
+            }
+        } catch (Exception e) {
+            getLog().error("Failed to setup CLI", e);
+            result.setErrorMessage("Failed to setup CLI : " + e.getMessage());
+        }
+        return result;
     }
 
     /**

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/HostControllerComponent.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/HostControllerComponent.java
@@ -126,6 +126,8 @@ public class HostControllerComponent<T extends ResourceComponent<?>> extends Bas
             operationResult = restartServer(parameters);
         } else if (name.equals("executeCommands") || name.equals("executeScript")) {
             return runCliCommand(parameters);
+        } else if (name.equals("setupCli")) {
+            return setupCli(parameters);
         } else if (name.equals("shutdown")) {
             // This is a bit trickier, as it needs to be executed on the level on /host=xx
             String domainHost = getASHostName();

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/StandaloneASComponent.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/StandaloneASComponent.java
@@ -194,6 +194,8 @@ public class StandaloneASComponent<T extends ResourceComponent<?>> extends BaseS
             return installManagementUser(parameters, pluginConfiguration);
         } else if (name.equals("executeCommands") || name.equals("executeScript")) {
             return runCliCommand(parameters);
+        } else if (name.equals("setupCli")) {
+            return setupCli(parameters);
         }
 
         // reload, shutdown go to the remote server

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/JBossCliConfiguration.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/JBossCliConfiguration.java
@@ -1,0 +1,389 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2015 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+package org.rhq.modules.plugins.jbossas7.helper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Comment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import org.rhq.core.util.file.FileUtil;
+
+/**
+ * A JBoss CLI configuration - loaded from jboss-cli.xml
+ *
+ * @author Libor Zoubek
+ */
+public class JBossCliConfiguration {
+
+    private final Log log = LogFactory.getLog(JBossCliConfiguration.class);
+
+    private Document document;
+    private XPathFactory xpathFactory;
+    private final File jbossCliXml;
+    private final ServerPluginConfiguration serverConfig;
+
+    /**
+     *
+     * @param jbossCliXml absolute path to jboss-cli.xml file
+     */
+    public JBossCliConfiguration(File jbossCliXml, ServerPluginConfiguration serverConfig) throws Exception {
+        this.jbossCliXml = jbossCliXml;
+        this.serverConfig = serverConfig;
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        InputStream is = new FileInputStream(jbossCliXml);
+        try {
+            this.document = builder.parse(is);
+        } finally {
+            is.close();
+        }
+        this.xpathFactory = XPathFactory.newInstance();
+    }
+
+    private Comment createComment() {
+        return this.document.createComment(" added by RHQ plugin ");
+    }
+
+    /**
+     * Setup SSL configuration properties by reading it from HostConfiguration (XML File) and expecting VAULT 
+     * to be present. 
+     * @param hostConfig
+     * @return
+     */
+    public String configureSecurityUsingVault(HostConfiguration hostConfig) {
+        Map<String, String> vaultOptions = hostConfig.getVault();
+        if (vaultOptions == null) {
+            return "Vault definition was not found in server configuration file";
+        }
+        TruststoreConfig serverIdentity = hostConfig.getServerIdentityKeystore();
+        if (serverIdentity == null) {
+            return "Could not find ssl configuration for management interface";
+        }
+
+        JBossCliConstants constants = getCliConstants();
+        if (constants.version().compareTo("1.3") < 0) {
+            return "Cannot store truststore passwords using vault, because it is not supported by this version of EAP";
+        }
+
+        Node sslNode = (Node) xpathExpression("/jboss-cli/ssl", XPathConstants.NODE);
+        // clean-up existing ssl node
+        if (sslNode != null) {
+            this.document.getDocumentElement().removeChild(sslNode);
+        }
+        sslNode = addChildElement(document.getDocumentElement(), "ssl");
+        sslNode.appendChild(createComment());
+
+        Node vaultNode = this.document.createElement("vault");
+        sslNode.appendChild(vaultNode);
+
+        for (Entry<String, String> vaultOpt : vaultOptions.entrySet()) {
+            Element opt = addChildElement(vaultNode, "vault-option");
+            opt.setAttribute("name", vaultOpt.getKey());
+            opt.setAttribute("value", vaultOpt.getValue());
+        }
+
+        addChildElement(sslNode, constants.alias(), serverIdentity.getAlias());
+        addChildElement(sslNode, constants.truststore(), serverIdentity.getPath());
+        // in standalone.xml vault value is referred as ${VAULT:...} we need to strip it for jboss-cli.xml
+        addChildElement(sslNode, constants.truststorePassword(), stripBrackets(serverIdentity.getKeystorePassword()));
+
+        TruststoreConfig clientKeystore = hostConfig.getClientAuthenticationTruststore();
+        if (clientKeystore != null) { // 2-way authentication properties
+            addChildElement(sslNode, constants.keystore(), clientKeystore.getPath());
+            addChildElement(sslNode, constants.keystorePassword(), stripBrackets(clientKeystore.getKeystorePassword()));
+            addChildElement(sslNode, constants.keyPassword(), stripBrackets(clientKeystore.getKeyPassword()));
+        }
+        return null;
+    }
+
+    /**
+     * Setup SSL configuration properties by reading it from ServerPluginConfiguration and writing it as plain text
+     * @return null if any configuration change has been made, otherwise message indicating reason why it was not changed
+     */
+    public String configureSecurity() {
+        if (serverConfig.isSecure()) {
+            if (serverConfig.getTruststore() != null) {
+                Node sslNode = (Node) xpathExpression("/jboss-cli/ssl", XPathConstants.NODE);
+                // clean-up existing ssl node
+                if (sslNode != null) {
+                    this.document.getDocumentElement().removeChild(sslNode);
+                }
+                sslNode = addChildElement(document.getDocumentElement(), "ssl");
+                sslNode.appendChild(createComment());
+
+                JBossCliConstants constants = getCliConstants();
+
+                addChildElement(sslNode, constants.truststore(), serverConfig.getTruststore());
+                addChildElement(sslNode, constants.truststorePassword(), serverConfig.getTruststorePassword());
+                if (serverConfig.isClientcertAuthentication()) {
+                    addChildElement(sslNode, constants.keystore(), serverConfig.getKeystore());
+                    addChildElement(sslNode, constants.keystorePassword(), serverConfig.getKeystorePassword());
+                    addChildElement(sslNode, constants.keyPassword(), serverConfig.getKeyPassword());
+                }
+                return null;
+            }
+            return "Truststore path is not set";
+        }
+        return "Secure connection is not enabled";
+    }
+
+
+    /**
+     * 
+     * @return corresponding constants based on xml namespace version
+     */
+    JBossCliConstants getCliConstants() {
+        String ns = this.document.getDocumentElement().getAttribute("xmlns");
+        String[] split = ns.split(":"); // urn:jboss:cli:1.3
+        if (split.length != 4) {
+            // unable to parse
+            return new JBossCliConstants10();
+        }
+        String versionStr = split[3];
+        // 1.3 and all future versions
+        if (versionStr.compareTo("1.3") >= 0) {
+            return new JBossCliConstants13();
+        }
+        if (versionStr.compareTo("1.2") == 0) {
+            return new JBossCliConstants12();
+        }
+        if (versionStr.compareTo("1.1") == 0) {
+            return new JBossCliConstants11();
+        }
+        return new JBossCliConstants10();
+    }
+    /**
+     * strips ${} expression from given string
+     * @param value
+     * @return
+     */
+    private String stripBrackets(String value) {
+        if (value != null && value.length() > 3 && value.startsWith("${")) {
+            return value.substring(2, value.length() - 1);
+        }
+        return value;
+    }
+
+    /**
+     * Setup controller host and port defaults
+     * @return null if any configuration change has been made, otherwise message indicating reason why it was not changed
+     */
+    public String configureDefaultController() {
+        Node ctrlNode = this.document.createElement("default-controller");
+        ctrlNode.appendChild(createComment());
+        addChildElement(ctrlNode, "host", serverConfig.getNativeHost());
+        addChildElement(ctrlNode, "port", String.valueOf(serverConfig.getNativePort()));
+        Node existing = (Node) xpathExpression("/jboss-cli/default-controller", XPathConstants.NODE);
+        if (existing != null) {
+            this.document.getDocumentElement().replaceChild(ctrlNode, existing);
+        }
+        return null;
+    }
+
+    /**
+     * Write changes to file - flushes changes made by i.e. {@link #configureSecurity()}. This also creates backup of the 
+     * file (appends ".original" suffix)
+     * @throws Exception
+     */
+    public void writeToFile() throws Exception {
+        if (!jbossCliXml.canWrite()) {
+            throw new IOException(jbossCliXml + " is not writable");
+        }
+        File backup = new File(jbossCliXml.getParentFile(), jbossCliXml.getName() + ".original");
+        try {
+            log.debug("Backup " + jbossCliXml + " to " + backup);
+            FileUtil.copyFile(jbossCliXml, backup);
+        } catch (IOException ex) {
+            throw new IOException("Could not create backup file " + backup, ex);
+        }
+
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+        //initialize StreamResult with File object to save to file
+        StreamResult result = new StreamResult(this.jbossCliXml);
+        DOMSource source = new DOMSource(this.document);
+        transformer.transform(source, result);
+    }
+
+    private void addChildElement(Node parent, String tagName, String textContent) {
+        if (tagName != null && textContent != null && !textContent.isEmpty()) {
+            Node element = this.document.createElement(tagName);
+            element.setTextContent(textContent);
+            parent.appendChild(element);
+        }
+    }
+
+    private Element addChildElement(Node parent, String tagName) {
+        Element element = this.document.createElement(tagName);
+        parent.appendChild(element);
+        return element;
+    }
+
+    public String obtainXmlPropertyViaXPath(String xpathExpression) {
+        return (String) xpathExpression(xpathExpression, XPathConstants.STRING);
+    }
+
+    private Object xpathExpression(String xpathExpression, QName returnType) {
+        XPath xpath = this.xpathFactory.newXPath();
+        try {
+            XPathExpression expr = xpath.compile(xpathExpression);
+            return expr.evaluate(this.document, returnType);
+        } catch (XPathExpressionException e) {
+            log.error("Evaluation of XPath expression failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * tagNames in jboss-cli.xml were changing overtime. We need to provide the right set of tagNames for 
+     * each known version of jboss-cli.xml schema
+     * @author lzoubek
+     *
+     */
+    static interface JBossCliConstants {
+        String version();
+
+        String truststore();
+
+        String truststorePassword();
+
+        String keystore();
+
+        String keystorePassword();
+
+        String alias();
+
+        String keyPassword();
+    }
+
+    private static class JBossCliConstants10 implements JBossCliConstants {
+
+        @Override
+        public String version() {
+            return "1.0";
+        }
+
+        @Override
+        public String truststore() {
+            return "trustStore";
+        }
+
+        @Override
+        public String truststorePassword() {
+            return "trustStorePassword";
+        }
+
+        @Override
+        public String keystore() {
+            return "keyStore";
+        }
+
+        @Override
+        public String keystorePassword() {
+            return "keyStorePassword";
+        }
+
+        @Override
+        public String alias() {
+            return null;
+        }
+
+        @Override
+        public String keyPassword() {
+            return null;
+        }
+    }
+
+    private static class JBossCliConstants11 extends JBossCliConstants10 {
+        @Override
+        public String version() {
+            return "1.1";
+        }
+
+        @Override
+        public String truststore() {
+            return "trust-store";
+        }
+
+        @Override
+        public String truststorePassword() {
+            return "trust-store-password";
+        }
+
+        @Override
+        public String keystore() {
+            return "key-store";
+        }
+
+        @Override
+        public String keystorePassword() {
+            return "key-store-password";
+        }
+
+        @Override
+        public String alias() {
+            return "alias";
+        }
+
+        @Override
+        public String keyPassword() {
+            return "key-password";
+        }
+    }
+
+    static class JBossCliConstants12 extends JBossCliConstants11 {
+        @Override
+        public String version() {
+            return "1.2";
+        }
+    }
+
+    static class JBossCliConstants13 extends JBossCliConstants12 {
+        @Override
+        public String version() {
+            return "1.3";
+        }
+    }
+}

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/TruststoreConfig.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/TruststoreConfig.java
@@ -1,0 +1,75 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2015 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package org.rhq.modules.plugins.jbossas7.helper;
+
+import org.w3c.dom.Node;
+
+/**
+ * 
+ * @author lzoubek
+ *
+ */
+public class TruststoreConfig {
+
+    public static TruststoreConfig fromXmlNode(Node node) {
+        if (node == null) {
+            return null;
+        }
+
+        Node attrAlias = node.getAttributes().getNamedItem("alias");
+        Node attrPath = node.getAttributes().getNamedItem("path");
+        Node attrKeystorePass = node.getAttributes().getNamedItem("keystore-password");
+        Node attrKeyPass = node.getAttributes().getNamedItem("keys-password");
+
+        return new TruststoreConfig(
+            attrAlias != null ? attrAlias.getNodeValue() : null,
+            attrPath != null ? attrPath.getNodeValue() : null,
+            attrKeystorePass != null ? attrKeystorePass.getNodeValue() : null,
+            attrKeyPass != null ? attrKeyPass.getNodeValue() : null);
+    }
+
+    private TruststoreConfig(String alias, String path, String keystorePassword, String keyPassword) {
+        this.alias = alias;
+        this.path = path;
+        this.keystorePassword = keystorePassword;
+        this.keyPassword = keyPassword;
+    }
+
+    private final String alias;
+    private final String path;
+    private final String keystorePassword;
+    private final String keyPassword;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getKeyPassword() {
+        return keyPassword;
+    }
+
+}

--- a/modules/plugins/jboss-as-7/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/jboss-as-7/src/main/resources/META-INF/rhq-plugin.xml
@@ -1055,6 +1055,39 @@
         	<c:simple-property name="operationResult" type="longString"/>
       	</results>
 	</operation>
+    <operation name="setupCli" displayName="Setup CLI" description="Setup jboss-cli.xml configuration file based on pluginConfiguration properties. Note that jboss-cli.xml was introduced in EAP 6.2 and this operation will fail for previous versions.">
+        <parameters>
+            <c:simple-property name="defaultController" required="false" type="boolean" defaultValue="false" description="Configure controller host and port defaults. When jboss-cli is executed later on, there is no need to specify controller address." />
+            <c:simple-property name="security" required="false" type="boolean" defaultValue="false">
+                <c:description>
+                    In case this server has secured management interface, jboss-cli.xml can be configured to trust server certificate
+                    from server truststore or to authenticate using Client certificate the same way as plugin does.
+                </c:description>
+            </c:simple-property>
+            <c:simple-property name="storePasswordMethod" defaultValue="PLAIN" type="string" required="false">
+                <c:description>
+                    Method to be used to store passwords to jboss-cli.xml when setting up Security. This setting is ignored unless &lt;strong&gt;Security&lt;/strong&gt; is enabled.
+                    &lt;ul&gt;
+                    &lt;li&gt;
+                        &lt;strong&gt;PLAIN&lt;/strong&gt; - Reads truststore/keystore passwords are read from server Plugin Configuration and written as plain text. This is default option.
+                    &lt;/li&gt;
+                    &lt;li&gt;
+                        &lt;strong&gt;VAULT&lt;/strong&gt; - Reads truststore/keystore passwords from server configuration file (ie. standalone.xml).
+                        Passwords must be obfuscated by vault. Vault must also be defined in server configuration file. If vault is not found, this operations results in Failure.
+                        Note that vaults in jboss-cli.xml were introduced in EAP 6.3, this operation will fail for earlier versions.
+                    &lt;/li&gt;
+                    &lt;/ul&gt;
+                 </c:description>
+                 <c:property-options>
+                     <c:option value="PLAIN"/>
+                     <c:option value="VAULT"/>
+                 </c:property-options>
+              </c:simple-property>
+        </parameters>
+        <results>
+            <c:simple-property name="operationResult" type="longString"/>
+        </results>
+    </operation>
 '>
     ]>
 <plugin name="&pluginName;"

--- a/modules/plugins/jboss-as-7/src/test/java/org/rhq/modules/plugins/jbossas7/XmlFileReadingTest.java
+++ b/modules/plugins/jboss-as-7/src/test/java/org/rhq/modules/plugins/jbossas7/XmlFileReadingTest.java
@@ -2,11 +2,13 @@ package org.rhq.modules.plugins.jbossas7;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
 import org.rhq.modules.plugins.jbossas7.helper.HostConfiguration;
 import org.rhq.modules.plugins.jbossas7.helper.HostPort;
+import org.rhq.modules.plugins.jbossas7.helper.TruststoreConfig;
 
 /**
  * Test the ability to read information from the AS7 standalone.xml or host.xml config files using
@@ -165,6 +167,43 @@ public class XmlFileReadingTest {
         url = getClass().getClassLoader().getResource("standalone-1.5-local-native-only.xml");
         hostConfig = new HostConfiguration(new File(url.getPath()));
         assert hostConfig.isNativeLocalOnly() == true;
+    }
+
+    public void testReadVault() throws Exception {
+        URL url = getClass().getClassLoader().getResource("standalone71.xml");
+        HostConfiguration hostConfig = new HostConfiguration(new File(url.getPath()));
+        assert hostConfig.getVault() == null;
+
+        url = getClass().getClassLoader().getResource("standalone711.xml");
+        hostConfig = new HostConfiguration(new File(url.getPath()));
+        Map<String, String> vaultOptions = hostConfig.getVault();
+        System.out.println(vaultOptions);
+        assert vaultOptions != null;
+        assert vaultOptions.size() == 6;
+
+        assert vaultOptions.containsKey("SALT");
+        assert vaultOptions.get("SALT").equals("1234abcd");
+    }
+
+    public void testReadTruststoreConfigs() throws Exception {
+        URL url = getClass().getClassLoader().getResource("standalone71.xml");
+        HostConfiguration hostConfig = new HostConfiguration(new File(url.getPath()));
+        assert hostConfig.getClientAuthenticationTruststore() == null;
+        assert hostConfig.getServerIdentityKeystore() == null;
+
+        url = getClass().getClassLoader().getResource("standalone711.xml");
+        hostConfig = new HostConfiguration(new File(url.getPath()));
+        TruststoreConfig serverIdentity = hostConfig.getServerIdentityKeystore();
+        assert serverIdentity != null;
+        assert serverIdentity.getPath().equals("keystore.jks");
+        assert serverIdentity.getAlias().equals("as7");
+        assert serverIdentity.getKeystorePassword().equals("secure");
+
+        TruststoreConfig clientTruststore = hostConfig.getClientAuthenticationTruststore();
+        assert clientTruststore != null;
+        assert clientTruststore.getPath().equals("truststore.jks");
+        assert clientTruststore.getAlias() == null;
+        assert clientTruststore.getKeystorePassword().equals("secured");
     }
 
 }

--- a/modules/plugins/jboss-as-7/src/test/java/org/rhq/modules/plugins/jbossas7/helper/JBossCliConfigurationTest.java
+++ b/modules/plugins/jboss-as-7/src/test/java/org/rhq/modules/plugins/jbossas7/helper/JBossCliConfigurationTest.java
@@ -1,0 +1,131 @@
+package org.rhq.modules.plugins.jbossas7.helper;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.modules.plugins.jbossas7.helper.ServerPluginConfiguration.Property;
+
+/**
+ * 
+ * @author lzoubek
+ *
+ */
+@Test(groups = "unit")
+public class JBossCliConfigurationTest {
+
+    JBossCliConfiguration cliConfig;
+    ServerPluginConfiguration serverConfig;
+    Configuration pluginConfig;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        File jbossCliXml = new File(getClass().getClassLoader().getResource("jboss-cli-1.3.xml").toURI());
+        pluginConfig = Configuration.builder()
+            .addSimple(Property.SECURE, "true")
+            .addSimple(Property.TRUSTSTORE, "/tmp/truststore")
+            .addSimple(Property.TRUSTSTORE_PASSWORD, "truststorepass")
+            .addSimple(Property.CLIENTCERT_AUTHENTICATION, true)
+            .addSimple(Property.KEYSTORE, "/tmp/keystore")
+            .addSimple(Property.KEYSTORE_PASSWORD, "keystorepass")
+            .addSimple(Property.KEY_PASSWORD, "keypass")
+            .addSimple(Property.NATIVE_HOST, "1.1.1.1")
+            .addSimple(Property.NATIVE_PORT, 123456)
+            .build();
+        serverConfig = new ServerPluginConfiguration(pluginConfig);
+        cliConfig = new JBossCliConfiguration(jbossCliXml, serverConfig);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void fileDoesNotExist() throws Exception {
+        cliConfig = new JBossCliConfiguration(new File(UUID.randomUUID().toString()), serverConfig);
+    }
+
+    public void detectVersion() {
+        Assert.assertEquals(cliConfig.getCliConstants().version(), "1.3");
+    }
+
+    public void defaultController() {
+        assert cliConfig.configureDefaultController() == null;
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/default-controller/host"), "1.1.1.1");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/default-controller/port"), "123456");
+    }
+
+    public void securityNoChangesNotSecure() {
+        pluginConfig.remove(Property.SECURE);
+        assert cliConfig.configureSecurity() != null;
+    }
+
+    public void securityNoChangesNoTruststore() {
+        pluginConfig.remove(Property.TRUSTSTORE);
+        assert cliConfig.configureSecurity() != null;
+    }
+
+    public void security() {
+        assert cliConfig.configureSecurity() == null;
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store"), "/tmp/truststore");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store-password"),
+            "truststorepass");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-store"), "/tmp/keystore");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-store-password"), "keystorepass");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-password"), "keypass");
+    }
+
+    public void securityUsingVault() throws Exception {
+        URL url = getClass().getClassLoader().getResource("standalone711.xml");
+        HostConfiguration hostConfig = new HostConfiguration(new File(url.getPath()));
+
+        Assert.assertNull(cliConfig.configureSecurityUsingVault(hostConfig));
+
+        // VAULT was written and KEYSTORE_URL option was taken from standalone711.xml
+        Assert.assertEquals(
+            cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/vault/vault-option[@name='KEYSTORE_URL']/@value"),
+            "EAP_HOME/vault/vault.keystore");
+
+        // assert SSL related values were taken from standalone711.xml
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store"), "keystore.jks");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store-password"), "secure");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-store"), "truststore.jks");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-store-password"), "secured");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-password"), "");
+    }
+
+    public void securitySChemaVersion10() throws Exception {
+        File jbossCliXml = new File(getClass().getClassLoader().getResource("jboss-cli-1.0.xml").toURI());
+        cliConfig = new JBossCliConfiguration(jbossCliXml, serverConfig);
+
+        Assert.assertEquals(cliConfig.getCliConstants().version(), "1.0");
+
+        // this hostConfiguration has vault defined
+        URL url = getClass().getClassLoader().getResource("standalone711.xml");
+        HostConfiguration hostConfig = new HostConfiguration(new File(url.getPath()));
+
+        // jboss-cli.xml schema version 1.0 does not support vault passwords - expect failure
+        Assert.assertEquals(cliConfig.configureSecurityUsingVault(hostConfig),
+            "Cannot store truststore passwords using vault, because it is not supported by this version of EAP");
+
+        // jboss-cli.xml schema version 1.0 uses camelCase element names
+        Assert.assertNull(cliConfig.configureSecurity());
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store"), "");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trustStore"), "/tmp/truststore");
+    }
+
+
+    public void securityNoClientCertAuth() {
+        pluginConfig.setSimpleValue(Property.CLIENTCERT_AUTHENTICATION, String.valueOf(false));
+        assert cliConfig.configureSecurity() == null;
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store"), "/tmp/truststore");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/trust-store-password"),
+            "truststorepass");
+        // key-store related properties must not be set
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-store"), "");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-store-password"), "");
+        Assert.assertEquals(cliConfig.obtainXmlPropertyViaXPath("/jboss-cli/ssl/key-password"), "");
+    }
+}

--- a/modules/plugins/jboss-as-7/src/test/resources/jboss-cli-1.0.xml
+++ b/modules/plugins/jboss-as-7/src/test/resources/jboss-cli-1.0.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+   JBoss AS7 Command-line Interface configuration.
+-->
+<jboss-cli xmlns="urn:jboss:cli:1.0">
+
+    <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
+    <default-controller>
+        <host>localhost</host>
+        <port>9999</port>
+    </default-controller>
+    
+    <validate-operation-requests>true</validate-operation-requests>
+    
+    <!-- whether to resolve system properties specified as command argument or operation parameter values
+         in the CLI VM before sending the operation requests to the controller -->
+    <resolve-parameter-values>false</resolve-parameter-values>
+    
+    <!-- Command and operation history log configuration -->
+    <history>
+        <enabled>true</enabled>
+        <file-name>.jboss-cli-history</file-name>
+        <file-dir>${user.home}</file-dir>
+        <max-size>500</max-size>
+    </history>
+    
+    <!-- Whether to write info and error messages to the terminal output -->
+    <silent>false</silent>
+</jboss-cli>

--- a/modules/plugins/jboss-as-7/src/test/resources/jboss-cli-1.3.xml
+++ b/modules/plugins/jboss-as-7/src/test/resources/jboss-cli-1.3.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+   JBoss AS7 Command-line Interface configuration.
+-->
+<jboss-cli xmlns="urn:jboss:cli:1.3">
+
+    <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
+    <default-controller>
+        <host>localhost</host>
+        <port>9999</port>
+    </default-controller>
+    
+    <validate-operation-requests>true</validate-operation-requests>
+    
+    <!-- whether to resolve system properties specified as command argument or operation parameter values
+         in the CLI VM before sending the operation requests to the controller -->
+    <resolve-parameter-values>false</resolve-parameter-values>
+    
+    <!-- Command and operation history log configuration -->
+    <history>
+        <enabled>true</enabled>
+        <file-name>.jboss-cli-history</file-name>
+        <file-dir>${user.home}</file-dir>
+        <max-size>500</max-size>
+    </history>
+    
+    <!-- Whether to write info and error messages to the terminal output -->
+    <silent>false</silent>
+</jboss-cli>

--- a/modules/plugins/jboss-as-7/src/test/resources/standalone711.xml
+++ b/modules/plugins/jboss-as-7/src/test/resources/standalone711.xml
@@ -50,8 +50,14 @@
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">
+                <server-identities>
+                    <ssl>
+                        <keystore alias="as7" keystore-password="secure" path="keystore.jks" />
+                    </ssl>
+                </server-identities>
                 <authentication>
                     <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                    <truststore path="truststore.jks" keystore-password="secured"/>
                 </authentication>
             </security-realm>
             <security-realm name="ApplicationRealm">
@@ -69,7 +75,14 @@
             </http-interface>
         </management-interfaces>
     </management>
-
+    <vault>
+      <vault-option name="KEYSTORE_URL" value="EAP_HOME/vault/vault.keystore"/>
+      <vault-option name="KEYSTORE_PASSWORD" value="vault22"/>
+      <vault-option name="KEYSTORE_ALIAS" value="vault"/>
+      <vault-option name="SALT" value="1234abcd"/>
+      <vault-option name="ITERATION_COUNT" value="120"/>
+      <vault-option name="ENC_FILE_DIR" value="EAP_HOME/vault/vault/"/>
+    </vault>
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:1.1">
             <console-handler name="CONSOLE">


### PR DESCRIPTION
Added operation called "Setup CLI" which can change jboss-cli.xml according
to pluginConfiguration properties. It can configure SSL stuff + default
controller host + port. Operation is present for Standalone and Host
Controllers.