### PR TITLE
Bug 1230411 - Storage node results in 1000s of configuration changes …

### DIFF
--- a/modules/plugins/cassandra/src/main/java/org/rhq/plugins/cassandra/CassandraNodeComponent.java
+++ b/modules/plugins/cassandra/src/main/java/org/rhq/plugins/cassandra/CassandraNodeComponent.java
@@ -28,6 +28,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -79,6 +81,7 @@ public class CassandraNodeComponent extends JMXServerComponent<ResourceComponent
 
     private String host;
     private ProcessInfo processInfo;
+    private InetAddress hostAddress;
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -87,7 +90,18 @@ public class CassandraNodeComponent extends JMXServerComponent<ResourceComponent
 
         processInfo = context.getNativeProcess();
         host = context.getPluginConfiguration().getSimpleValue("host", "localhost");
+
+        try {
+            hostAddress = InetAddress.getByName(this.host);
+        } catch (UnknownHostException e) {
+            log.error("Unable to convert hostname[" + this.host + "] into IP address for " + context.getResourceKey(),
+                e);
+        }
     };
+
+    public InetAddress getHostAddress() {
+        return hostAddress;
+    }
 
     @Override
     public void stop() {

--- a/modules/plugins/cassandra/src/main/java/org/rhq/plugins/cassandra/ComplexConfigurationResourceComponent.java
+++ b/modules/plugins/cassandra/src/main/java/org/rhq/plugins/cassandra/ComplexConfigurationResourceComponent.java
@@ -20,11 +20,15 @@
 
 package org.rhq.plugins.cassandra;
 
+import java.net.InetAddress;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
+import org.apache.cassandra.net.MessagingService;
 import org.mc4j.ems.connection.bean.attribute.EmsAttribute;
 
 import org.rhq.core.domain.configuration.Configuration;
@@ -36,15 +40,120 @@ import org.rhq.core.domain.configuration.definition.PropertyDefinition;
 import org.rhq.core.domain.configuration.definition.PropertyDefinitionList;
 import org.rhq.core.domain.configuration.definition.PropertyDefinitionMap;
 import org.rhq.core.domain.configuration.definition.PropertyDefinitionSimple;
+import org.rhq.core.domain.measurement.MeasurementDataNumeric;
+import org.rhq.core.domain.measurement.MeasurementReport;
+import org.rhq.core.domain.measurement.MeasurementScheduleRequest;
 import org.rhq.core.pluginapi.configuration.ConfigurationUpdateReport;
+import org.rhq.core.pluginapi.operation.OperationResult;
 import org.rhq.plugins.jmx.JMXComponent;
 import org.rhq.plugins.jmx.MBeanResourceComponent;
 
 /**
- * @author Stefan Negrea
+ * @author Stefan Negrea, Libor Zoubek
  *
  */
 public class ComplexConfigurationResourceComponent extends MBeanResourceComponent<JMXComponent<?>> {
+
+
+    /**
+     * finds Cassandra node component
+     * @return Cassandra component or null if it could not be found
+     */
+    protected CassandraNodeComponent getCassandraComponent() {
+        JMXComponent<?> component = this;
+        while ((component != null) && !(component instanceof CassandraNodeComponent)) {
+            if (component instanceof MBeanResourceComponent<?>) {
+                component = ((MBeanResourceComponent<?>) component).getResourceContext().getParentResourceComponent();
+            } else {
+                return null;
+            }
+        }
+        return (CassandraNodeComponent) component;
+    }
+
+    /**
+     * reads MBean attribute  value (result type of Map<String,String> is expected) as operation result. Parameters 'keyName' and 'valueName'
+     * denote names of SimpleProperties within produced OperationResult should by same as defined in plugin descriptor
+     * @param name operation name = attributeName to read
+     * @param keyName name of key to be written to result map
+     * @param valueName name of value  to be written to result map 
+     * @return Operation result with complex result (List of Map<name,value>)
+     * @see MessagingService or StorageService plugin descriptor
+     */
+    protected OperationResult invokeReadAttributeOperationComplexResult(String name, String keyName, String valueName) {
+        OperationResult result = new OperationResult();
+        EmsAttribute attribute = getEmsBean().getAttribute(name);
+        Object valueObject = attribute.refresh();
+        PropertyList resultList = new PropertyList("operationResult");
+        result.getComplexResults().put(resultList);
+        if (valueObject instanceof Map<?, ?>) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> map = (Map<String, String>) valueObject;
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                PropertyMap entryMap = new PropertyMap("entry");
+                resultList.add(entryMap);
+                entryMap.put(new PropertySimple(keyName, entry.getKey()));
+                entryMap.put(new PropertySimple(valueName, entry.getValue()));
+            }
+        } else {
+            result.setErrorMessage("Failed to read response");
+        }
+        return result;
+    }
+
+    @Override
+    public void getValues(MeasurementReport report, Set<MeasurementScheduleRequest> requests) {
+        // handle special metrics starting with "host:"
+        // such MBeans are expected to return Map<Host,Value> and we'll have to find value of current host (current node)
+        Set<MeasurementScheduleRequest> filtered = new HashSet<MeasurementScheduleRequest>(requests.size());
+        for (MeasurementScheduleRequest request : requests) {
+            if (!readHostMetric(request, report)) {
+                filtered.add(request);
+            }
+        }
+        super.getValues(report, filtered);
+    }
+
+    /**
+     * reads host-related metric value. It is expected, that metric specified in `request` is prefixed
+     * by "host:" in it's name and, returned MBean attribute value type is Map<Host,Value>. This method 
+     * finds current {@link CassandraNodeComponent#getHost()} in map and adds it's value into report
+     * @param request
+     * @param report
+     * @return true if given request name was prefixed with "host:", false otherwise
+     */
+    private boolean readHostMetric(MeasurementScheduleRequest request, MeasurementReport report) {
+        if (!request.getName().startsWith("host:")) {
+            return false;
+        }
+        CassandraNodeComponent cassandra = getCassandraComponent();
+        if (cassandra == null || cassandra.getHostAddress() == null) {
+            return true;
+        }
+        InetAddress host = cassandra.getHostAddress();
+        String metricName = request.getName().substring(5); // strip out "host:"
+        EmsAttribute attribute = getEmsBean().getAttribute(metricName);
+        Object valueObject = attribute.refresh();
+        if (valueObject instanceof Map<?, ?>) {
+            @SuppressWarnings("unchecked")
+            Map<InetAddress, Float> hostMetric = (Map<InetAddress, Float>) valueObject;
+            Float value = hostMetric.get(host);
+            if (value == null) {
+                // the inet address wasn't probably resolved, scan the map
+                for (Map.Entry<InetAddress, Float> entry : hostMetric.entrySet()) {
+                    if (entry.getKey().getHostAddress().equals(host.getHostAddress())) {
+                        value = entry.getValue();
+                        break;
+                    }
+                }
+            }
+            if (value != null) {
+                report.addData(new MeasurementDataNumeric(request, value.doubleValue()));
+            }
+
+        }
+        return true;
+    }
 
     @SuppressWarnings({ "unchecked", "deprecation" })
     @Override

--- a/modules/plugins/cassandra/src/main/java/org/rhq/plugins/cassandra/MessagingServiceComponent.java
+++ b/modules/plugins/cassandra/src/main/java/org/rhq/plugins/cassandra/MessagingServiceComponent.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * RHQ Management Platform
+ *  * Copyright (C) 2005-2015 Red Hat, Inc.
+ *  * All rights reserved.
+ *  *
+ *  * This program is free software; you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License, version 2, as
+ *  * published by the Free Software Foundation, and/or the GNU Lesser
+ *  * General Public License, version 2.1, also as published by the Free
+ *  * Software Foundation.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  * GNU General Public License and the GNU Lesser General Public License
+ *  * for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * and the GNU Lesser General Public License along with this program;
+ *  * if not, write to the Free Software Foundation, Inc.,
+ *  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+package org.rhq.plugins.cassandra;
+
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.core.pluginapi.operation.OperationResult;
+
+/**
+ * 
+ * @author lzoubek
+ *
+ */
+public class MessagingServiceComponent extends ComplexConfigurationResourceComponent {
+
+    public OperationResult invokeOperation(String name, Configuration parameters) throws Exception {
+        if ("DroppedMessages".equals(name) || "RecentlyDroppedMessages".equals(name)) {
+            return invokeReadAttributeOperationComplexResult(name, "name", "value");
+        }
+        return super.invokeOperation(name, parameters);
+    };
+}

--- a/modules/plugins/cassandra/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/cassandra/src/main/resources/META-INF/rhq-plugin.xml
@@ -198,6 +198,17 @@
         </parameters>
       </operation>
 
+      <operation name="TokenToEndpointMap" displayName="View Token To Endpoint Map">
+        <results>
+          <c:list-property name="operationResult" description="Token To Endpoint Map">
+            <c:map-property name="entry">
+              <c:simple-property name="token" type="string" />
+              <c:simple-property name="endpoint" type="string" />
+            </c:map-property>
+          </c:list-property>
+        </results>
+      </operation>
+
       <metric property="Calculated.DataDiskUsedPercentage" displayName="Data File Disk Used Percentage" dataType="measurement" units="percentage" displayType="summary" description="Percentage of disk space used by Cassandra data files. The aggregate accross all the partitions will be reported if multiple data locations are specified. This is a calculated metric derived from system and Cassandra runtime information."/>
       <metric property="Calculated.TotalDiskUsedPercentage" displayName="Total Disk Used Percentage" dataType="measurement" units="percentage" displayType="summary" description="Percentage of total disk space used. The metric acounts overall disk usage (including system files), not just disk space used by Cassandra. The aggregate accross all the partitions will be reported if multiple data locations are specified. This is a calculated metric derived from system and Cassandra runtime information."/>
       <metric property="Calculated.FreeDiskToDataSizeRatio" displayName="Free Disk to Data Size Ratio" dataType="measurement" displayType="summary" description="Ratio of (Free Disk)/(Data File Size). A value below 1 is not recommended since a compaction or repair process could double the amount of disk space used by data files. The aggregate accross all the partitions will be reported if multiple data locations are specified. This is a calculated metric derived from system and Cassandra runtime information."/>
@@ -251,26 +262,8 @@
           <c:list-property name="JoiningNodes" readOnly="true" description="List of nodes currently joining the ring.">
             <c:simple-property name="node" readOnly="true"/>
           </c:list-property>
-          <c:list-property name="LoadMap" readOnly="true" description="Human-readable load values for the cluster.">
-              <c:map-property name="entry" readOnly="true">
-                <c:simple-property name="endpoint" readOnly="true"/>
-                <c:simple-property name="load" readOnly="true"/>
-              </c:map-property>
-          </c:list-property>
           <c:list-property name="MovingNodes" readOnly="true" description="List of nodes currently moving the ring.">
             <c:simple-property name="node" readOnly="true"/>
-          </c:list-property>
-          <c:list-property name="Ownership" readOnly="true" description="Mapping of token -> percentage of cluster owned by that token">
-              <c:map-property name="entry" readOnly="true">
-                <c:simple-property name="token" readOnly="true"/>
-                <c:simple-property name="percentage" readOnly="true"/>
-              </c:map-property>
-          </c:list-property>
-          <c:list-property name="TokenToEndpointMap" readOnly="true" description="Token To Endpoint Map">
-              <c:map-property name="entry" readOnly="true">
-                <c:simple-property name="token" readOnly="true"/>
-                <c:simple-property name="endpoint" readOnly="true"/>
-              </c:map-property>
           </c:list-property>
           <c:list-property name="UnreachableNodes" readOnly="true" description="List of unreachable nodes in the cluster, as determined by this node's failure detector.">
             <c:simple-property name="node" readOnly="true"/>
@@ -601,7 +594,7 @@
 
     <service name="MessagingService"
              discovery="org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent"
-             class="org.rhq.plugins.cassandra.ComplexConfigurationResourceComponent"
+             class="org.rhq.plugins.cassandra.MessagingServiceComponent"
              singleton="true"
              subCategory="Network Services">
 
@@ -609,63 +602,40 @@
         <c:simple-property name="objectName" readOnly="true" default="org.apache.cassandra.net:type=MessagingService"/>
         <c:simple-property name="nameTemplate" readOnly="true" type="string" default="Messaging Service"/>
       </plugin-configuration>
+      
+      <operation name="DroppedMessages" displayName="List Dropped Messages">
+        <results>
+          <c:list-property name="operationResult" description="Dropped Messages">
+            <c:map-property name="entry">
+              <c:simple-property name="name" type="string" />
+              <c:simple-property name="value" type="string" />
+            </c:map-property>
+          </c:list-property>
+        </results>
+      </operation>
+      <operation name="RecentlyDroppedMessages" displayName="List Recently Dropped Messages">
+        <results>
+          <c:list-property name="operationResult" description="Recently Dropped Messages">
+            <c:map-property name="entry">
+              <c:simple-property name="name" type="string" />
+              <c:simple-property name="value" type="string" />
+            </c:map-property>
+          </c:list-property>
+        </results>
+      </operation>
 
       <metric property="TotalTimeouts" measurementType="trendsup" displayType="detail" description="Total timeouts."/>
-      <metric property="RecentTotalTimouts" measurementType="trendsup" displayType="detail" description="Recent total timeouts."/>
+      <metric property="RecentTotalTimouts" measurementType="trendsup" displayType="detail" description="Recent total timeouts"/>
 
-      <resource-configuration>
-        <c:list-property name="CommandPendingTasks" readOnly="true">
-          <c:map-property name="CommandPendingTask" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-        <c:list-property name="CommandCompletedTasks" readOnly="true">
-          <c:map-property name="CommandCompletedTask" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
+      <metric property="host:CommandPendingTasks" displayName="Command Pending Tasks" dataType="measurement"  displayType="detail" />
+      <metric property="host:CommandCompletedTasks" measurementType="trendsup" displayName="Command Completed Tasks" dataType="measurement"  displayType="detail" />
+      
+      <metric property="host:ResponsePendingTasks" displayName="Response Pending Tasks" dataType="measurement"  displayType="detail" />
+      <metric property="host:ResponseCompletedTasks" measurementType="trendsup" displayName="Response Completed Tasks" dataType="measurement"  displayType="detail" />
+      
+      <metric property="host:TimeoutsPerHost" measurementType="trendsup" displayName="Host Timeouts" dataType="measurement"  displayType="detail" />
+      <metric property="host:RecentTimeoutsPerHost" displayName="Host Recent Timeouts" dataType="measurement"  displayType="detail" />
 
-        <c:list-property name="ResponsePendingTasks" readOnly="true">
-          <c:map-property name="ResponsePendingTask" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-        <c:list-property name="ResponseCompletedTasks" readOnly="true">
-          <c:map-property name="ResponseCompletedTask" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-
-        <c:list-property name="DroppedMessages" readOnly="true">
-          <c:map-property name="DroppedMessage" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-        <c:list-property name="RecentlyDroppedMessages" readOnly="true">
-          <c:map-property name="RecentlyDroppedMessage" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-
-        <c:list-property name="TimeoutsPerHost" readOnly="true">
-          <c:map-property name="TimeoutPerHost" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-        <c:list-property name="RecentTimeoutsPerHost" readOnly="true">
-          <c:map-property name="RecentTimeoutPerHost" readOnly="true">
-              <c:simple-property name="name" type="string" readOnly="true"/>
-              <c:simple-property name="value" type="string" readOnly="true"/>
-          </c:map-property>
-        </c:list-property>
-      </resource-configuration>
     </service>
 
 


### PR DESCRIPTION
…filling

up the database

Several Configuration properties were transformed to metrics or operations.

StorageService resourceType: LoadMap and Ownership config properties were
removed (metrics already existed) we're "loosing" information about other
nodes (which can be obtained on those node resources). TokenToEndpointMap
property was removed and transformed to operation called "View Token To Map
Ednpoint"

MessagingService resourceType:DroppedMessages and RecentlyDroppedMessages
transformed to operations, all other config properties transformed to
metrics (no properties left)