### PR TITLE
Bug 833547 - make agent shutdown timeout configurable

### DIFF
--- a/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentConfiguration.java
+++ b/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentConfiguration.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
-import mazz.i18n.Logger;
-
 import org.rhq.core.pc.PluginContainerConfiguration;
 import org.rhq.core.util.obfuscation.ObfuscatedPreferences;
 import org.rhq.enterprise.agent.i18n.AgentI18NFactory;
@@ -37,6 +35,8 @@ import org.rhq.enterprise.communications.ServiceContainerConfiguration;
 import org.rhq.enterprise.communications.command.client.ClientCommandSenderConfiguration;
 import org.rhq.enterprise.communications.command.client.PersistentFifo;
 import org.rhq.enterprise.communications.util.SecurityUtil;
+
+import mazz.i18n.Logger;
 
 /**
  * Just provides some convienence methods to extract agent configuration properties.
@@ -372,6 +372,11 @@ public class AgentConfiguration {
         String str = m_preferences.get(AgentConfigurationConstants.AGENT_UPDATE_VERSION_URL, null);
 
         return str;
+    }
+
+    public long getAgentUpdateExitTimeout() {
+        return m_preferences.getLong(AgentConfigurationConstants.AGENT_UPDATE_EXIT_TIMEOUT_MSECS,
+            AgentConfigurationConstants.DEFAULT_AGENT_UPDATE_EXIT_TIMEOUT_MSECS);
     }
 
     /**

--- a/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentConfigurationConstants.java
+++ b/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentConfigurationConstants.java
@@ -162,6 +162,16 @@ public interface AgentConfigurationConstants {
     String AGENT_UPDATE_DOWNLOAD_URL = PROPERTY_NAME_PREFIX + "agent-update.download-url";
 
     /**
+     * The amount of milliseconds the agent will wait before force closing after an update.
+     */
+    String AGENT_UPDATE_EXIT_TIMEOUT_MSECS = PROPERTY_NAME_PREFIX + "agent-update.exit-timeout-msecs";
+
+    /**
+     * If the update-exit timeout is not defined, this is the default.
+     */
+    long DEFAULT_AGENT_UPDATE_EXIT_TIMEOUT_MSECS = 1000L * 60 * 1;
+
+    /**
      * The amount of milliseconds the agent will wait at startup for the server to be detected.
      */
     String WAIT_FOR_SERVER_AT_STARTUP_MSECS = PROPERTY_NAME_PREFIX + "wait-for-server-at-startup-msecs";

--- a/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentUpdateThread.java
+++ b/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentUpdateThread.java
@@ -216,7 +216,7 @@ public class AgentUpdateThread extends Thread {
 
         // We should only ever get here if everything was successful.
         // We now need to exit the thread; and if everything goes according to plan, the VM will now exit
-        shutdownHook.spawnKillThread(1000L * 60 * 1); // pull the pin - FIRE IN THE HOLE!
+        shutdownHook.spawnKillThread(this.agent.getConfiguration().getAgentUpdateExitTimeout()); // pull the pin - FIRE IN THE HOLE!
         return;
     }
 


### PR DESCRIPTION
Takes the configuration from the AgentConfiguration.
Created the defaults in the AgentConfigurationConstants.
The configuration is taken from the entry: "rhq.agent.agent-update-exit-timeout-msecs".