### PR TITLE
Bug 1268329 - The same user is able to upload bundle via 'Upload' but…

### DIFF
--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/server/gwt/BundleGWTServiceImpl.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/server/gwt/BundleGWTServiceImpl.java
@@ -71,7 +71,7 @@ public class BundleGWTServiceImpl extends AbstractGWTServiceImpl implements Bund
     public BundleVersion createOrStoreBundleVersionViaURL(String url, String username, String password)
         throws RuntimeException {
         try {
-            BundleVersion results = bundleManager.createBundleVersionViaURL(getSessionSubject(), url, username,
+            BundleVersion results = bundleManager.createOrStoreBundleVersionViaURL(getSessionSubject(), url, username,
                 password);
             return SerialUtility.prepare(results, "createOrStoreBundleVersionViaURL");
         } catch (Throwable t) {

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/bundle/BundleManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/bundle/BundleManagerBean.java
@@ -883,7 +883,7 @@ public class BundleManagerBean implements BundleManagerLocal, BundleManagerRemot
             if (null != e.getCause() && e.getCause() instanceof BundleNotFoundException) {
                 deleteFile = false;
                 // This application exception indicates the special token handling workflow
-                throw new BundleNotFoundException("[" + distributionFileUrl + "]");
+                throw new BundleNotFoundException("[" + file.getName() + "]");
             } else {
                 throw e;
             }
@@ -929,7 +929,8 @@ public class BundleManagerBean implements BundleManagerLocal, BundleManagerRemot
     }
 
     private File slurp(InputStream is) throws IOException {
-        File file = File.createTempFile("bundle-distribution", ".zip");
+        File file = File.createTempFile("bundle-distribution", ".zip",
+            new File(System.getProperty("jboss.server.temp.dir")));
 
         StreamUtil.copy(is, new FileOutputStream(file));
 


### PR DESCRIPTION
… not via 'URL'

Instead of returning the URL as the token, moved to the temp dir to match the special token handling worflow.
Unpacked the BundleNotFoundException from the RunTimeException that is throw to the client.
Was using BundleManager.createBundleVersionViaURL instead of BundleManager.createOrStoreBundleVersionViaURL (The caller method is "createOrStoreBundleVersionViaURL"), changed to match method signature.