### PR TITLE
Bug 1302322 - Secure server-agent communication using sslsocket incor…

### DIFF
--- a/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentMain.java
+++ b/modules/enterprise/agent/src/main/java/org/rhq/enterprise/agent/AgentMain.java
@@ -20,8 +20,6 @@
 package org.rhq.enterprise.agent;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import gnu.getopt.Getopt;
-import gnu.getopt.LongOpt;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -77,9 +75,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import mazz.i18n.Logger;
-import mazz.i18n.Msg;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.xml.DOMConfigurator;
@@ -94,6 +89,7 @@ import org.jboss.remoting.invocation.NameBasedInvocation;
 import org.jboss.remoting.security.SSLSocketBuilder;
 import org.jboss.remoting.transport.http.ssl.HTTPSClientInvoker;
 import org.jboss.util.file.FilenameSuffixFilter;
+
 import org.rhq.core.clientapi.agent.lifecycle.PluginContainerLifecycle;
 import org.rhq.core.clientapi.server.bundle.BundleServerService;
 import org.rhq.core.clientapi.server.configuration.ConfigurationServerService;
@@ -188,6 +184,11 @@ import org.rhq.enterprise.communications.command.server.IncomingCommandTrace;
 import org.rhq.enterprise.communications.util.CommandTraceUtil;
 import org.rhq.enterprise.communications.util.NotProcessedException;
 import org.rhq.enterprise.communications.util.SecurityUtil;
+
+import gnu.getopt.Getopt;
+import gnu.getopt.LongOpt;
+import mazz.i18n.Logger;
+import mazz.i18n.Msg;
 
 /**
  * The main class of the agent runtime container.
@@ -2872,8 +2873,11 @@ public class AgentMain {
                 m_configuration.getClientSenderSecurityTruststoreAlgorithm());
             config.put(SSLSocketBuilder.REMOTING_TRUST_STORE_TYPE,
                 m_configuration.getClientSenderSecurityTruststoreType());
-            config.put(SSLSocketBuilder.REMOTING_TRUST_STORE_PASSWORD,
-                m_configuration.getClientSenderSecurityTruststorePassword());
+            // ClientSenderSecurityTruststorePassword property is optional and should not be stored if null.
+            if (m_configuration.getClientSenderSecurityTruststorePassword() != null) {
+                config.put(SSLSocketBuilder.REMOTING_TRUST_STORE_PASSWORD,
+                    m_configuration.getClientSenderSecurityTruststorePassword());
+            }
             config.put(SSLSocketBuilder.REMOTING_SSL_PROTOCOL, m_configuration.getClientSenderSecuritySocketProtocol());
             config.put(SSLSocketBuilder.REMOTING_KEY_ALIAS, m_configuration.getClientSenderSecurityKeystoreAlias());
             config.put(SSLSocketBuilder.REMOTING_SERVER_AUTH_MODE,


### PR DESCRIPTION
…rectly requires a truststore password.

Made ClientSenderSecurityTruststorePassword(client.security.truststore.password) property optional, no longer
storing null in the configuration map. This avoids passing a map with nulls to org.jboss.remoting.Client which
causes an Exception on it's connect method.