### PR TITLE
Add resource definition or the build fails (Maven 3.3.9)

### DIFF
--- a/modules/common/cassandra-ccm/cassandra-ccm-core/pom.xml
+++ b/modules/common/cassandra-ccm/cassandra-ccm-core/pom.xml
@@ -86,6 +86,10 @@
                 <exclude>src/main/resources/cassandra/conf/cassandra-env.sh</exclude>
               </excludes>
             </resource>
+            <resource>
+              <directory>src/main/bundle</directory>
+              <filtering>false</filtering>
+            </resource>
           </resources>
           <delimiters>
             <delimiter>${*}</delimiter>


### PR DESCRIPTION
If if I don't add this, the build fails because src/main/bundle resources don't get copied over to target/classes