### PR TITLE
Bug 1312405 - EAP7 - unable to create xa datasource - At least one xa-datasource-property is required

### DIFF
--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/DatasourcesComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/DatasourcesComponent.java
@@ -20,8 +20,16 @@
 package org.rhq.modules.plugins.wildfly10;
 
 import static java.lang.Boolean.TRUE;
-import static org.rhq.core.domain.resource.CreateResourceStatus.*;
-import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.*;
+import static org.rhq.core.domain.resource.CreateResourceStatus.FAILURE;
+import static org.rhq.core.domain.resource.CreateResourceStatus.INVALID_ARTIFACT;
+import static org.rhq.core.domain.resource.CreateResourceStatus.SUCCESS;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.CONNECTION_PROPERTIES_ATTRIBUTE;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.DISABLE_OPERATION;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.ENABLED_ATTRIBUTE;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.ENABLE_OPERATION;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.XA_DATASOURCE_PROPERTIES_ATTRIBUTE;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.getConnectionPropertiesAsMap;
+import static org.rhq.modules.plugins.wildfly10.DatasourceComponent.isXADatasourceResource;
 
 import java.util.List;
 import java.util.Map;
@@ -33,7 +41,11 @@ import org.rhq.core.domain.configuration.PropertySimple;
 import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
 import org.rhq.core.domain.resource.ResourceType;
 import org.rhq.core.pluginapi.inventory.CreateResourceReport;
-import org.rhq.modules.plugins.wildfly10.json.*;
+import org.rhq.modules.plugins.wildfly10.json.Address;
+import org.rhq.modules.plugins.wildfly10.json.CompositeOperation;
+import org.rhq.modules.plugins.wildfly10.json.Operation;
+import org.rhq.modules.plugins.wildfly10.json.ReadAttribute;
+import org.rhq.modules.plugins.wildfly10.json.Result;
 
 /**
  * A component for Datasources resources (parent type of Datasource and XA Datasource resources).

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/domain/BundleContentHandoverTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/domain/BundleContentHandoverTest.java
@@ -39,13 +39,13 @@ import org.rhq.core.pluginapi.bundle.BundleHandoverRequest;
 import org.rhq.core.pluginapi.bundle.BundleHandoverResponse;
 import org.rhq.core.util.exception.ThrowableUtil;
 import org.rhq.modules.plugins.wildfly10.itest.AbstractJBossAS7PluginTest;
-import org.rhq.modules.plugins.wildfly10.test.util.ASConnectionFactory;
-import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.modules.plugins.wildfly10.json.Address;
 import org.rhq.modules.plugins.wildfly10.json.Operation;
 import org.rhq.modules.plugins.wildfly10.json.ReadAttribute;
 import org.rhq.modules.plugins.wildfly10.json.ReadResource;
 import org.rhq.modules.plugins.wildfly10.json.Result;
+import org.rhq.modules.plugins.wildfly10.test.util.ASConnectionFactory;
+import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.test.arquillian.RunDiscovery;
 
 /**

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/domain/SecurityModuleOptionsTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/domain/SecurityModuleOptionsTest.java
@@ -58,15 +58,15 @@ import org.rhq.core.domain.resource.ResourceCategory;
 import org.rhq.core.domain.resource.ResourceType;
 import org.rhq.core.pc.configuration.ConfigurationManager;
 import org.rhq.core.pc.inventory.InventoryManager;
-import org.rhq.modules.plugins.wildfly10.itest.AbstractJBossAS7PluginTest;
-import org.rhq.modules.plugins.wildfly10.test.util.ASConnectionFactory;
-import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.modules.plugins.wildfly10.ASConnection;
 import org.rhq.modules.plugins.wildfly10.ModuleOptionsComponent.ModuleOptionType;
 import org.rhq.modules.plugins.wildfly10.ModuleOptionsComponent.Value;
+import org.rhq.modules.plugins.wildfly10.itest.AbstractJBossAS7PluginTest;
 import org.rhq.modules.plugins.wildfly10.json.Address;
 import org.rhq.modules.plugins.wildfly10.json.Operation;
 import org.rhq.modules.plugins.wildfly10.json.Result;
+import org.rhq.modules.plugins.wildfly10.test.util.ASConnectionFactory;
+import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.test.arquillian.RunDiscovery;
 
 /**

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/nonpc/AbstractIntegrationTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/nonpc/AbstractIntegrationTest.java
@@ -48,13 +48,13 @@ import org.rhq.core.clientapi.descriptor.plugin.ServerDescriptor;
 import org.rhq.core.clientapi.descriptor.plugin.ServiceDescriptor;
 import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
 import org.rhq.core.util.stream.StreamUtil;
-import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.modules.plugins.wildfly10.ASConnectionParams;
 import org.rhq.modules.plugins.wildfly10.ASConnectionParamsBuilder;
 import org.rhq.modules.plugins.wildfly10.ASUploadConnection;
 import org.rhq.modules.plugins.wildfly10.json.Address;
 import org.rhq.modules.plugins.wildfly10.json.Operation;
 import org.rhq.modules.plugins.wildfly10.json.PROPERTY_VALUE;
+import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 
 /**
  * Abstract base class for integration tests that do not run against an RHQ plugin container.

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/nonpc/ManagementConnectionPersistenceTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/nonpc/ManagementConnectionPersistenceTest.java
@@ -33,13 +33,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.modules.plugins.wildfly10.ASConnection;
 import org.rhq.modules.plugins.wildfly10.ASConnectionParams;
 import org.rhq.modules.plugins.wildfly10.ASConnectionParamsBuilder;
 import org.rhq.modules.plugins.wildfly10.json.Address;
 import org.rhq.modules.plugins.wildfly10.json.ReadAttribute;
 import org.rhq.modules.plugins.wildfly10.json.Result;
+import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 
 /**
  * Test {@link ASConnection} behavior with respect to management http connection persistence.

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/nonpc/ServerGroupTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/itest/nonpc/ServerGroupTest.java
@@ -25,11 +25,11 @@ import org.rhq.core.domain.resource.CreateResourceStatus;
 import org.rhq.core.domain.resource.ResourceCategory;
 import org.rhq.core.domain.resource.ResourceType;
 import org.rhq.core.pluginapi.inventory.CreateResourceReport;
-import org.rhq.modules.plugins.wildfly10.test.util.ASConnectionFactory;
-import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 import org.rhq.modules.plugins.wildfly10.ASConnection;
 import org.rhq.modules.plugins.wildfly10.HostControllerComponent;
 import org.rhq.modules.plugins.wildfly10.json.Remove;
+import org.rhq.modules.plugins.wildfly10.test.util.ASConnectionFactory;
+import org.rhq.modules.plugins.wildfly10.test.util.Constants;
 
 /**
  * Tests around server groups


### PR DESCRIPTION
Bug 1312405 - EAP7 - unable to create xa datasource - At least one xa-datasource-property is required

EAP7, unlike EAP6, wants xa-datasource-properties to be part of the creation operation.
Same applies to regular datasource.