### PR TITLE
Bug 1317993 - Application fails to deploy on EAP7 when the rt filter is installed

### DIFF
--- a/modules/helpers/rtfilter-wfly-10-subsystem/src/main/java/org/rhq/helpers/rtfilter/subsystem/wfly10/deployment/RtFilterDeploymentUnitProcessor.java
+++ b/modules/helpers/rtfilter-wfly-10-subsystem/src/main/java/org/rhq/helpers/rtfilter/subsystem/wfly10/deployment/RtFilterDeploymentUnitProcessor.java
@@ -29,6 +29,7 @@ import org.jboss.as.server.deployment.*;
 import org.jboss.as.web.common.WarMetaData;
 import org.jboss.logging.Logger;
 import org.jboss.metadata.javaee.spec.ParamValueMetaData;
+import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.metadata.web.spec.FilterMappingMetaData;
 import org.jboss.metadata.web.spec.FilterMetaData;
 import org.jboss.metadata.web.spec.FiltersMetaData;
@@ -63,7 +64,7 @@ public class RtFilterDeploymentUnitProcessor implements DeploymentUnitProcessor 
             log.debug("Configuring RHQ response-time servlet filter for WAR " + deploymentUnit.getName() + "...");
 
             final WarMetaData warMetaData = deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY);
-            WebMetaData webMetaData = warMetaData.getWebMetaData();
+            JBossWebMetaData webMetaData = warMetaData.getMergedJBossWebMetaData();
 
             FilterMetaData rtFilter = null;
             FiltersMetaData filters = webMetaData.getFilters();


### PR DESCRIPTION
Bug 1317993 - Application fails to deploy on EAP7 when the rt filter is installed

#getWebMetaData only gives you the content from web.xml, and may be null if deployment descriptor is omitted
#getMergedJBossWebMetaData gives you the content aggregated from all sources (defaults from subsystem config, values from deployment descriptor), and never returns null