### PR TITLE
Bug 1313955 - Check if "/" is the only value of the last key.

### DIFF
--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/json/Address.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/json/Address.java
@@ -86,7 +86,10 @@ public class Address {
             path = path.substring(1);
         }
         if (path.endsWith("/")) {
-            path = path.substring(0, path.length() - 1);
+            // We need to check that this "/" isn't the only value of the last key.
+            if (!path.endsWith("=/")) {
+                path = path.substring(0, path.length() - 1);
+            }
         }
         // Now split on comma boundaries
         String[] components = PATH_PATTERN.split(path);


### PR DESCRIPTION
Fixes these exceptions: https://bugzilla.redhat.com/show_bug.cgi?id=1313955#c4

The problem was that "Address" removes the "/" that are at the beginning and end of path, thus throwing a java.lang.ArrayIndexOutOfBoundsException when trying to get the value of location key.

example path: subsystem=undertow,server=default-server,host=default-host,location=/

Though at this point I'm not sure if we should allow "/" at the end of some keys (e.g. location) or if it will be OK to only check if "/" is the only value of the last key.