### PR TITLE
Bug 1246083 - CLI operations don't work when Native Local Authenticat…

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseProcessDiscovery.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseProcessDiscovery.java
@@ -213,10 +213,18 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         initLogEventSourcesConfigProp(logFile.getPath(), pluginConfig);
 
         HostPort managementHostPort = hostConfig.getManagementHostPort(commandLine, getMode());
+        if ("0.0.0.0".equals(managementHostPort.host)) {
+            LOG.debug("Discovered management host set to 0.0.0.0, falling back to 127.0.0.1");
+            managementHostPort.host = "127.0.0.1";
+        }
         serverPluginConfig.setHostname(managementHostPort.host);
         serverPluginConfig.setPort(managementHostPort.port);
         serverPluginConfig.setSecure(managementHostPort.isSecure);
         HostPort nativeHostPort = hostConfig.getNativeHostPort(commandLine, getMode());
+        if ("0.0.0.0".equals(nativeHostPort.host)) {
+            LOG.debug("Discovered native management host set to 0.0.0.0, falling back to 127.0.0.1");
+            nativeHostPort.host = "127.0.0.1";
+        }
         serverPluginConfig.setNativeHost(nativeHostPort.host);
         serverPluginConfig.setNativePort(nativeHostPort.port);
         serverPluginConfig.setNativeLocalAuth(hostConfig.isNativeLocalOnly());

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseServerComponent.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseServerComponent.java
@@ -117,6 +117,10 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
         super.start(resourceContext);
         serverPluginConfig = new ServerPluginConfiguration(pluginConfiguration);
         serverPluginConfig.validate();
+        if ("0.0.0.0".equals(serverPluginConfig.getNativeHost())) {
+            LOG.warn("Native management host is set to 0.0.0.0 on server " + resourceContext.getResourceKey()
+                + ". Please change this to avoid operation failures");
+        }
         connection = new ASConnection(ASConnectionParams.createFrom(serverPluginConfig));
         setASHostName(findASDomainHostName());
         getAvailability();

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/HostConfiguration.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/HostConfiguration.java
@@ -186,9 +186,9 @@ public class HostConfiguration {
         hp.isSecure = isSecure;
 
         if (!interfaceExpression.isEmpty()) {
-            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "localhost");
+            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "127.0.0.1");
         } else {
-            hp.host = "localhost"; // Fallback
+            hp.host = "127.0.0.1"; // Fallback
         }
 
         hp.port = 0;
@@ -302,9 +302,9 @@ public class HostConfiguration {
         HostPort hp = new HostPort();
 
         if (!interfaceExpression.isEmpty()) {
-            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "localhost");
+            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "127.0.0.1");
         } else {
-            hp.host = "localhost"; // Fallback
+            hp.host = "127.0.0.1"; // Fallback
         }
 
         hp.port = 0;


### PR DESCRIPTION
…ion is enabled and Native management API host is set to 0.0.0.0

Updated discovery class so that when '0.0.0.0' is discovered, '127.0.0.1' is used
Updated component class to log a warning if native host is set to '0.0.0.0'
Changed defaults from 'localhost' to '127.0.0.1' in HostConfiguration class to avoid troubles when localhost is configured to something else than loopback address

Note that, with these changes, new servers bound to '0.0.0.0' will no longer have this address in the resource name, but '127.0.0.1' instead.
Resource keys are not impacted. Already inventoried EAP6 resources are left untouched.