### PR TITLE
Bug 1311094 - EAP7 - Native management API port incorrectly detected

### DIFF
--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
@@ -42,7 +42,6 @@ import org.rhq.core.domain.configuration.Configuration;
 import org.rhq.core.domain.configuration.PropertyList;
 import org.rhq.core.domain.configuration.PropertyMap;
 import org.rhq.core.domain.configuration.PropertySimple;
-import org.rhq.core.domain.resource.ResourceUpgradeReport;
 import org.rhq.core.pluginapi.event.log.LogFileEventResourceComponentHelper;
 import org.rhq.core.pluginapi.inventory.DiscoveredResourceDetails;
 import org.rhq.core.pluginapi.inventory.InvalidPluginConfigurationException;
@@ -50,8 +49,6 @@ import org.rhq.core.pluginapi.inventory.ManualAddFacet;
 import org.rhq.core.pluginapi.inventory.ProcessScanResult;
 import org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent;
 import org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext;
-import org.rhq.core.pluginapi.upgrade.ResourceUpgradeContext;
-import org.rhq.core.pluginapi.upgrade.ResourceUpgradeFacet;
 import org.rhq.core.pluginapi.util.CommandLineOption;
 import org.rhq.core.pluginapi.util.FileUtils;
 import org.rhq.core.pluginapi.util.JavaCommandLine;
@@ -69,7 +66,7 @@ import org.rhq.modules.plugins.wildfly10.json.Result;
  * Abstract base discovery component for the two server types - "JBossAS7 Host Controller" and
  * "JBossAS7 Standalone Server".
  */
-public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent, ManualAddFacet, ResourceUpgradeFacet {
+public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent, ManualAddFacet {
     private static final Log LOG = LogFactory.getLog(BaseProcessDiscovery.class);
 
     private static final String JBOSS_EAP_PREFIX = "jboss-eap-";
@@ -197,12 +194,13 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         initLogEventSourcesConfigProp(logFile.getPath(), pluginConfig);
 
         HostPort managementHostPort = hostConfig.getManagementHostPort(commandLine, getMode());
+        if ("0.0.0.0".equals(managementHostPort.host)) {
+            LOG.debug("Discovered management host set to 0.0.0.0, falling back to 127.0.0.1");
+            managementHostPort.host = "127.0.0.1";
+        }
         serverPluginConfig.setHostname(managementHostPort.host);
         serverPluginConfig.setPort(managementHostPort.port);
         serverPluginConfig.setSecure(managementHostPort.isSecure);
-        HostPort nativeHostPort = hostConfig.getNativeHostPort(commandLine, getMode());
-        serverPluginConfig.setNativeHost(nativeHostPort.host);
-        serverPluginConfig.setNativePort(nativeHostPort.port);
         serverPluginConfig.setNativeLocalAuth(hostConfig.isNativeLocalOnly());
         pluginConfig.setSimpleValue("realm", hostConfig.getManagementSecurityRealm());
         String apiVersion = hostConfig.getDomainApiVersion();
@@ -489,139 +487,6 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
             description, pluginConfig, null);
 
         return detail;
-    }
-
-    @Override
-    public ResourceUpgradeReport upgrade(ResourceUpgradeContext inventoriedResource) {
-        ResourceUpgradeReport report = new ResourceUpgradeReport();
-        boolean upgraded = false;
-
-        String currentResourceKey = inventoriedResource.getResourceKey();
-        Configuration pluginConfiguration = inventoriedResource.getPluginConfiguration();
-        ServerPluginConfiguration serverPluginConfiguration = new ServerPluginConfiguration(pluginConfiguration);
-
-        HostConfiguration hostConfig = null;
-        // load hostConfiguration just once - we need it several times
-        File hostXmlFile = serverPluginConfiguration.getHostConfigFile();
-        if (hostXmlFile != null && hostXmlFile.exists()) {
-            try {
-                hostConfig = loadHostConfiguration(hostXmlFile);
-            } catch (Exception e) {
-                LOG.error("Unable to upgrade resource " + inventoriedResource, e);
-                return null;
-            }
-        } else {
-            LOG.warn("Unable to upgrade resource " + inventoriedResource
-                + "Server configuration file not found at the expected location (" + hostXmlFile + ").");
-            return null;
-        }
-
-        boolean hasLocalResourcePrefix = currentResourceKey.startsWith(LOCAL_RESOURCE_KEY_PREFIX);
-        boolean hasRemoteResourcePrefix = currentResourceKey.startsWith(REMOTE_RESOURCE_KEY_PREFIX);
-        if (!hasLocalResourcePrefix && !hasRemoteResourcePrefix) {
-            // Resource key in wrong format
-            upgraded = true;
-            if (new File(currentResourceKey).isDirectory()) {
-                // Old key format for a local resource (key is base dir)
-                report.setNewResourceKey(createKeyForLocalResource(serverPluginConfiguration));
-            } else if (currentResourceKey.contains(":")) {
-                // Old key format for a remote (manually added) resource (key is base dir)
-                report.setNewResourceKey(createKeyForRemoteResource(currentResourceKey));
-            } else {
-                upgraded = false;
-                LOG.warn("Unknown format, cannot upgrade resource key [" + currentResourceKey + "]");
-            }
-        } else if (hasLocalResourcePrefix) {
-            String configFilePath = currentResourceKey.substring(LOCAL_RESOURCE_KEY_PREFIX.length());
-            File configFile = new File(configFilePath);
-            try {
-                String configFileCanonicalPath = configFile.getCanonicalPath();
-                if (!configFileCanonicalPath.equals(configFilePath)) {
-                    upgraded = true;
-                    report.setNewResourceKey(LOCAL_RESOURCE_KEY_PREFIX + configFileCanonicalPath);
-                }
-            } catch (IOException e) {
-                LOG.warn("Unexpected IOException while converting host config file path to its canonical form", e);
-            }
-        }
-
-        if (pluginConfiguration.getSimpleValue("expectedRuntimeProductName") == null) {
-            upgraded = true;
-            pluginConfiguration.setSimpleValue("expectedRuntimeProductName",
-                serverPluginConfiguration.getProductType().PRODUCT_NAME);
-            report.setNewPluginConfiguration(pluginConfiguration);
-        }
-
-        String supportsPatching = pluginConfiguration.getSimpleValue("supportsPatching");
-        if (supportsPatching == null || supportsPatching.startsWith("__UNINITIALIZED_")) {
-            upgraded = true;
-
-            JBossProductType productType = serverPluginConfiguration.getProductType();
-            if (productType == null) {
-                if (inventoriedResource.getNativeProcess() != null) {
-                    // if resource seems to run, detect product type
-                    try {
-                        AS7CommandLine commandLine = new AS7CommandLine(inventoriedResource.getNativeProcess());
-                        File homeDir = getHomeDir(inventoriedResource.getNativeProcess(), commandLine);
-                        String apiVersion = hostConfig.getDomainApiVersion();
-                        productType = JBossProductType.determineJBossProductType(homeDir, apiVersion);
-                        serverPluginConfiguration.setProductType(productType);
-                        pluginConfiguration.setSimpleValue("supportsPatching", Boolean.toString(true)); // @TODO Remove
-                        report.setNewPluginConfiguration(pluginConfiguration);
-                    } catch (Exception e) {
-                        LOG.warn("Unable to detect productType", e);
-                    }
-
-                } else {
-                    // we have to skip upgrading at this point since it is not running and we're unable to detect productType
-                    LOG.warn("Unable to upgrade resource "
-                        + inventoriedResource
-                        + " : resource is missing productType pluginConfiguration property and needs to be running in order to discover it");
-                    upgraded = false;
-                }
-            } else {
-                pluginConfiguration
-                .setSimpleValue("supportsPatching", Boolean.toString(true)); // Remove
-                report.setNewPluginConfiguration(pluginConfiguration);
-            }
-
-
-        }
-
-        if (inventoriedResource.getNativeProcess() != null) {
-            String origHost = serverPluginConfiguration.getNativeHost();
-            Integer origPort = serverPluginConfiguration.getNativePort();
-            // detect if server is running and has default values
-            if ("127.0.0.1".equals(origHost) && Integer.valueOf(9999).equals(origPort)) {
-                try {
-                    AS7CommandLine commandLine = new AS7CommandLine(inventoriedResource.getNativeProcess());
-                    HostPort hp = hostConfig.getNativeHostPort(commandLine, getMode());
-
-                    // only update pluginConfig if we detected a difference
-                    if (!origHost.equals(hp.host) || origPort.intValue() != hp.port) {
-                        serverPluginConfiguration.setNativeHost(hp.host);
-                        serverPluginConfiguration.setNativePort(hp.port);
-                        report.setNewPluginConfiguration(serverPluginConfiguration.getPluginConfig());
-                        LOG.info("Detected native host/port " + hp + " for " + inventoriedResource.getResourceKey());
-                        upgraded = true;
-                    }
-
-                } catch (Exception e) {
-                    LOG.error("Unable to detect and upgrade native management host and port", e);
-                }
-            }
-        }
-
-        if (pluginConfiguration.getSimpleValue(ServerPluginConfiguration.Property.NATIVE_LOCAL_AUTH) == null) {
-            serverPluginConfiguration.setNativeLocalAuth(hostConfig.isNativeLocalOnly());
-            report.setNewPluginConfiguration(serverPluginConfiguration.getPluginConfig());
-            upgraded = true;
-        }
-
-        if (upgraded) {
-            return report;
-        }
-        return null;
     }
 
     private String createKeyForRemoteResource(String hostPort) {

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseServerComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseServerComponent.java
@@ -115,6 +115,10 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
         super.start(resourceContext);
         serverPluginConfig = new ServerPluginConfiguration(pluginConfiguration);
         serverPluginConfig.validate();
+        if ("0.0.0.0".equals(serverPluginConfig.getHostname())) {
+            LOG.warn("Management host is set to 0.0.0.0 on server " + resourceContext.getResourceKey()
+                + ". Please change this to avoid operation failures");
+        }
         connection = new ASConnection(ASConnectionParams.createFrom(serverPluginConfig));
         setASHostName(findASDomainHostName());
         getAvailability();

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/ServerControl.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/ServerControl.java
@@ -293,8 +293,8 @@ public final class ServerControl {
             commands = commands.replace('\n', ',');
             String user = disconnected || local ? null : "--user=" + serverPluginConfig.getUser();
             String password = disconnected || local ? null : "--password=" + serverPluginConfig.getPassword();
-            String controller = disconnected ? null : "--controller=" + serverPluginConfig.getNativeHost() + ":"
-                + serverPluginConfig.getNativePort();
+            String controller = disconnected ? null : "--controller=" + serverPluginConfig.getHostname() + ":"
+                + serverPluginConfig.getPort();
 
             if (!disconnected && checkCertificate) {
                 // check whether we're able to talk to server and CLI won't block because it needs user to accept SSL certificate
@@ -341,8 +341,8 @@ public final class ServerControl {
             String file = "--file=" + script.getAbsolutePath();
             String user = disconnected || local ? null : "--user=" + serverPluginConfig.getUser();
             String password = disconnected || local ? null : "--password=" + serverPluginConfig.getPassword();
-            String controller = disconnected ? null : "--controller=" + serverPluginConfig.getNativeHost() + ":"
-                + serverPluginConfig.getNativePort();
+            String controller = disconnected ? null : "--controller=" + serverPluginConfig.getHostname() + ":"
+                + serverPluginConfig.getPort();
 
             if (!disconnected && checkCertificate) {
                 // check whether we're able to talk to server and CLI won't block because it needs user to accept SSL certificate

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/VersionedDomainDeploymentDiscovery.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/VersionedDomainDeploymentDiscovery.java
@@ -29,11 +29,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.rhq.core.domain.resource.ResourceUpgradeReport;
 import org.rhq.core.pluginapi.inventory.DiscoveredResourceDetails;
 import org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext;
-import org.rhq.core.pluginapi.upgrade.ResourceUpgradeContext;
-import org.rhq.core.pluginapi.upgrade.ResourceUpgradeFacet;
 
 /**
  * Discover domain deployments. This is analogous to {@link VersionedSubsystemDiscovery} but addresses only
@@ -41,8 +38,7 @@ import org.rhq.core.pluginapi.upgrade.ResourceUpgradeFacet;
  *
  * @author Jay Shaughnessy
  */
-public class VersionedDomainDeploymentDiscovery extends AbstractVersionedDomainDeploymentDiscovery implements
-    ResourceUpgradeFacet {
+public class VersionedDomainDeploymentDiscovery extends AbstractVersionedDomainDeploymentDiscovery {
 
     private static final Log LOG = LogFactory.getLog(VersionedDomainDeploymentDiscovery.class);
 
@@ -118,54 +114,5 @@ public class VersionedDomainDeploymentDiscovery extends AbstractVersionedDomainD
 
         details.addAll(updatedDetails);
         return details;
-    }
-
-    // The Matching logic here is the same as above, but instead of setting the discovery details we
-    // set new values in the upgrade report for name, version and key.  Note that if multiple resources
-    // upgrade to the same resource key it will be caught and fail downstream.
-    @Override
-    public ResourceUpgradeReport upgrade(ResourceUpgradeContext inventoriedResource) {
-        ResourceUpgradeReport result = null;
-
-        if (DISABLED) {
-            return result;
-        }
-
-        MATCHER.reset(inventoriedResource.getName());
-        if (MATCHER.matches()) {
-            result = new ResourceUpgradeReport();
-            result.setForceGenericPropertyUpgrade(true); // It is critical the name and version get upgraded
-
-            // reset the resource name with the stripped value
-            result.setNewName(MATCHER.group(1) + MATCHER.group(3));
-            result.setNewVersion(MATCHER.group(2));
-        }
-
-        StringBuilder sb = new StringBuilder();
-        String comma = "";
-        boolean upgradeKey = false;
-        for (String segment : COMMA_PATTERN.split(inventoriedResource.getResourceKey())) {
-            sb.append(comma);
-            comma = ",";
-            MATCHER.reset(segment);
-            if (MATCHER.matches()) {
-                upgradeKey = true;
-                sb.append(MATCHER.group(1)).append(MATCHER.group(3));
-            } else {
-                sb.append(segment);
-            }
-        }
-        if (upgradeKey) {
-            if (null == result) {
-                result = new ResourceUpgradeReport();
-            }
-            result.setNewResourceKey(sb.toString());
-        }
-
-        if (null != result && LOG.isDebugEnabled()) {
-            LOG.debug("Requesting upgrade: " + result);
-        }
-
-        return result;
     }
 }

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/HostConfiguration.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/HostConfiguration.java
@@ -186,130 +186,14 @@ public class HostConfiguration {
         hp.isSecure = isSecure;
 
         if (!interfaceExpression.isEmpty()) {
-            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "localhost");
+            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "127.0.0.1");
         } else {
-            hp.host = "localhost"; // Fallback
+            hp.host = "127.0.0.1"; // Fallback
         }
 
         hp.port = 0;
         if (portString != null && !portString.isEmpty()) {
             String tmp = replaceDollarExpression(portString, commandLine, String.valueOf(DEFAULT_MGMT_PORT));
-            hp.port = Integer.valueOf(tmp);
-        }
-
-        if (portOffsetRaw != null && !portOffsetRaw.isEmpty()) {
-            String portOffsetString = replaceDollarExpression(portOffsetRaw, commandLine, "0");
-            Integer portOffset = Integer.valueOf(portOffsetString);
-            hp.port += portOffset;
-            hp.withOffset = true;
-        } else if (mode == AS7Mode.STANDALONE) {
-            // On standalone servers, offset may also be set with a system property
-            String value = commandLine.getSystemProperties().get(SOCKET_BINDING_PORT_OFFSET_SYSPROP);
-            if (value != null) {
-                int offset = Integer.valueOf(value);
-                hp.port += offset;
-            }
-        }
-
-        return hp;
-    }
-
-    /**
-     * Try to obtain the management IP and port from the already parsed host.xml or standalone.xml
-     *
-     * @param commandLine Command line arguments of the process to
-     *
-     * @return an Object containing host and port
-     */
-    public HostPort getNativeHostPort(AS7CommandLine commandLine, AS7Mode mode) {
-        // There are three ways to configure the http(s) management endpoint
-        //
-        // 1. Standalone servers favored style (socket-binding style)
-        //     <management>
-        //         <management-interfaces>
-        //             <native-interface security-realm="ManagementRealm">
-        //                 <socket-binding native="management"/>
-        //             </native-interface>
-        //         </management-interfaces>
-        //     </management>
-        //
-        // 2. Host controllers style, unfavored standalone servers style (socket style)
-        //     <management>
-        //         <management-interfaces>
-        //             <native-interface security-realm="ManagementRealm">
-        //                 <socket interface="management" port="9999" />
-        //             </native-interface>
-        //         </management-interfaces>
-        //     </management>
-        //
-        //
-        // 3. Very old and deprecated style (early as7 style)
-        //     <management>
-        //         <management-interfaces>
-        //             <native-interface security-realm="ManagementRealm" interface="management" port="9999" />
-        //         </management-interfaces>
-        //     </management>
-
-        String portString;
-        String interfaceExpression;
-        String socketBindingName;
-        String portOffsetRaw = null;
-        boolean isSecure = false;
-        // detect http interface
-        if (findMatchingElements("//management/management-interfaces/native-interface/socket-binding").getLength() != 0) {
-            // This is case 1
-            socketBindingName = obtainXmlPropertyViaXPath("//management/management-interfaces/native-interface/socket-binding/@native");
-            portString = obtainXmlPropertyViaXPath("/server/socket-binding-group/socket-binding[@name='"
-                + socketBindingName + "']/@port");
-            String interfaceName = obtainXmlPropertyViaXPath("/server/socket-binding-group/socket-binding[@name='"
-                + socketBindingName + "']/@interface");
-            String xpathExpression = "/server/socket-binding-group/@port-offset";
-            portOffsetRaw = obtainXmlPropertyViaXPath(xpathExpression);
-
-            interfaceExpression = obtainXmlPropertyViaXPath("/server/interfaces/interface[@name='" + interfaceName
-                + "']/inet-address/@value");
-            if (interfaceExpression.isEmpty()) {
-                interfaceExpression = obtainXmlPropertyViaXPath("/server/interfaces/interface[@name='" + interfaceName
-                    + "']/loopback-address/@value");
-            }
-        } else if (findMatchingElements("//management/management-interfaces/native-interface/socket").getLength() != 0) {
-            // This is case 2
-            String socketInterface = obtainXmlPropertyViaXPath("//management/management-interfaces/native-interface/socket/@interface");
-            interfaceExpression = obtainXmlPropertyViaXPath("//interfaces/interface[@name='" + socketInterface
-                + "']/inet-address/@value");
-            if (interfaceExpression.isEmpty()) {
-                interfaceExpression = obtainXmlPropertyViaXPath("//interfaces/interface[@name='" + socketInterface
-                    + "']/loopback-address/@value");
-            }
-            portString = obtainXmlPropertyViaXPath("//management/management-interfaces/native-interface/socket/@port");
-        } else {
-            // This is case 3
-            portString = obtainXmlPropertyViaXPath("//management/management-interfaces/native-interface/@secure-port");
-            if (!portString.isEmpty()) {
-                isSecure = true;
-            } else {
-                portString = obtainXmlPropertyViaXPath("//management/management-interfaces/native-interface/@port");
-            }
-            String interfaceName = obtainXmlPropertyViaXPath("//management/management-interfaces/native-interface/@interface");
-            interfaceExpression = obtainXmlPropertyViaXPath("/server/interfaces/interface[@name='" + interfaceName
-                + "']/inet-address/@value");
-            if (interfaceExpression.isEmpty()) {
-                interfaceExpression = obtainXmlPropertyViaXPath("/server/interfaces/interface[@name='" + interfaceName
-                    + "']/loopback-address/@value");
-            }
-        }
-
-        HostPort hp = new HostPort();
-
-        if (!interfaceExpression.isEmpty()) {
-            hp.host = replaceDollarExpression(interfaceExpression, commandLine, "localhost");
-        } else {
-            hp.host = "localhost"; // Fallback
-        }
-
-        hp.port = 0;
-        if (portString != null && !portString.isEmpty()) {
-            String tmp = replaceDollarExpression(portString, commandLine, String.valueOf(DEFAULT_NATIVE_PORT));
             hp.port = Integer.valueOf(tmp);
         }
 

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/JBossCliConfiguration.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/JBossCliConfiguration.java
@@ -212,8 +212,8 @@ public class JBossCliConfiguration {
     public String configureDefaultController() {
         Node ctrlNode = this.document.createElement("default-controller");
         ctrlNode.appendChild(createComment());
-        addChildElement(ctrlNode, "host", serverConfig.getNativeHost());
-        addChildElement(ctrlNode, "port", String.valueOf(serverConfig.getNativePort()));
+        addChildElement(ctrlNode, "host", serverConfig.getHostname());
+        addChildElement(ctrlNode, "port", String.valueOf(serverConfig.getPort()));
         Node existing = (Node) xpathExpression("/jboss-cli/default-controller", XPathConstants.NODE);
         if (existing != null) {
             this.document.getDocumentElement().replaceChild(ctrlNode, existing);

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
@@ -40,8 +40,6 @@ public class ServerPluginConfiguration {
         public static final String HOSTNAME = "hostname";
         public static final String PORT = "port";
         public static final String SECURE = "secure";
-        public static final String NATIVE_HOST = "nativeHost";
-        public static final String NATIVE_PORT = "nativePort";
         public static final String NATIVE_LOCAL_AUTH = "nativeLocalAuth";
         public static final String USER = "user";
         public static final String PASSWORD = "password";
@@ -52,8 +50,6 @@ public class ServerPluginConfiguration {
         public static final String LOG_DIR = "logDir";
         public static final String PRODUCT_TYPE = "productType";
         public static final String HOST_CONFIG_FILE = "hostConfigFile";
-        @Deprecated
-        public static final String AVAIL_CHECK_PERIOD_CONFIG_PROP = "availabilityCheckPeriod";
         public static final String TRUST_STRATEGY = "trustStrategy";
         public static final String HOSTNAME_VERIFICATION = "hostnameVerification";
         public static final String TRUSTSTORE_TYPE = "truststoreType";
@@ -124,20 +120,6 @@ public class ServerPluginConfiguration {
         this.pluginConfig.setSimpleValue(Property.SECURE, String.valueOf(secure));
     }
 
-    public Integer getNativePort() {
-        String stringValue = this.pluginConfig.getSimpleValue(Property.NATIVE_PORT);
-        return (stringValue != null) ? Integer.valueOf(stringValue) : null;
-    }
-
-    public void setNativeHost(String host) {
-        this.pluginConfig.setSimpleValue(Property.NATIVE_HOST, host);
-    }
-
-    public String getNativeHost() {
-        return this.pluginConfig.getSimpleValue(Property.NATIVE_HOST);
-
-    }
-
     public boolean isNativeLocalAuth() {
         String stringValue = this.pluginConfig.getSimpleValue(Property.NATIVE_LOCAL_AUTH);
         return stringValue != null && Boolean.parseBoolean(stringValue);
@@ -145,10 +127,6 @@ public class ServerPluginConfiguration {
 
     public void setNativeLocalAuth(boolean nativeLocalAuth) {
         this.pluginConfig.setSimpleValue(Property.NATIVE_LOCAL_AUTH, String.valueOf(nativeLocalAuth));
-    }
-
-    public void setNativePort(int port) {
-        this.pluginConfig.setSimpleValue(Property.NATIVE_PORT, String.valueOf(port));
     }
 
     public String getUser() {
@@ -224,15 +202,6 @@ public class ServerPluginConfiguration {
     public void setHostConfigFile(File hostConfigFile) {
         this.pluginConfig.setSimpleValue(Property.HOST_CONFIG_FILE,
             (hostConfigFile != null) ? hostConfigFile.toString() : null);
-    }
-
-    @Deprecated
-    public Integer getAvailabilityCheckPeriod() {
-        return 0;
-    }
-
-    @Deprecated
-    public void setAvailabilityCheckPeriod(Integer availabilityCheckPeriod) {
     }
 
     public TrustStrategy getTrustStrategy() {

--- a/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
@@ -62,9 +62,7 @@
             for example: -c standalone-ha-full.xml. There is currently a 2000 character limit for this value.
           </c:description>
         </c:simple-property>
-        <c:simple-property name="nativeHost" default="127.0.0.1" required="true" description="Native management API host"/>
-        <c:simple-property name="nativePort" type="integer" required="true" default="9999" description="Native management API port" />
-        <c:simple-property name="nativeLocalAuth" required="false" displayName="Native Local Authentication" type="boolean">
+        <c:simple-property name="nativeLocalAuth" required="false" displayName="CLI Local Authentication" type="boolean">
           <c:description>
             Specifies if the local authentication should be used to interact with the EAP CLI 
             (this includes bundle:handover feature, EAP patching and CLI operations).
@@ -1565,9 +1563,7 @@
             for these changes to take effect.
           </c:description>
         </c:simple-property>
-        <c:simple-property name="nativeHost" default="127.0.0.1" required="true" description="Native management API host"/>
-        <c:simple-property name="nativePort" type="integer" required="true" default="9999" description="Native management API port" />
-        <c:simple-property name="nativeLocalAuth" required="false" displayName="Native Local Authentication" type="boolean">
+        <c:simple-property name="nativeLocalAuth" required="false" displayName="CLI Local Authentication" type="boolean">
             <c:description>
             Specifies if the local authentication should be used to interact with the EAP CLI 
             (this includes bundle:handover feature, EAP patching and CLI operations).

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/helper/JBossCliConfigurationTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/helper/JBossCliConfigurationTest.java
@@ -35,8 +35,6 @@ public class JBossCliConfigurationTest {
             .addSimple(Property.KEYSTORE, "/tmp/keystore")
             .addSimple(Property.KEYSTORE_PASSWORD, "keystorepass")
             .addSimple(Property.KEY_PASSWORD, "keypass")
-            .addSimple(Property.NATIVE_HOST, "1.1.1.1")
-            .addSimple(Property.NATIVE_PORT, 123456)
             .build();
         serverConfig = new ServerPluginConfiguration(pluginConfig);
         cliConfig = new JBossCliConfiguration(jbossCliXml, serverConfig);


### PR DESCRIPTION
Removed nativeHost and nativePort settings from EAP7 servers config, as the CLI now connects to the HTTP management port.

Updated discovery class so that when '0.0.0.0' is discovered, '127.0.0.1' is used
Updated component class to log a warning if management host is set to '0.0.0.0'
Changed default from 'localhost' to '127.0.0.1' in HostConfiguration class to avoid troubles when localhost is configured to something else than loopback address

Also, removed upgrade facet from wf10 plugin component classes