### PR TITLE
Bug 1311094 - EAP7 - Native management API port incorrectly detected

### DIFF
--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
@@ -196,9 +196,10 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         HostPort managementHostPort = hostConfig.getManagementHostPort(commandLine, getMode());
         if ("0.0.0.0".equals(managementHostPort.host)) {
             LOG.debug("Discovered management host set to 0.0.0.0, falling back to 127.0.0.1");
-            managementHostPort.host = "127.0.0.1";
+            serverPluginConfig.setHostname("127.0.0.1");
+        } else {
+            serverPluginConfig.setHostname(managementHostPort.host);
         }
-        serverPluginConfig.setHostname(managementHostPort.host);
         serverPluginConfig.setPort(managementHostPort.port);
         serverPluginConfig.setSecure(managementHostPort.isSecure);
         serverPluginConfig.setNativeLocalAuth(hostConfig.isNativeLocalOnly());


### PR DESCRIPTION
Bug 1311094 - EAP7 - Native management API port incorrectly detected

Update to previous fix: keep 0.0.0.0 in resource name