### PR TITLE
[BZ 1313863] Add support for patching of EAP7 instances

### DIFF
--- a/modules/common/wfly-patch-parser/src/main/java/org/rhq/common/wildfly/Patch.java
+++ b/modules/common/wfly-patch-parser/src/main/java/org/rhq/common/wildfly/Patch.java
@@ -44,6 +44,7 @@ public final class Patch {
     private final String id;
     private final Type type;
     private final String identityName;
+    private final PatchProductType productType;
     private final String targetVersion;
     private final String description;
     private final String contents;
@@ -52,6 +53,7 @@ public final class Patch {
         this.id = id;
         this.type = type;
         this.identityName = identityName;
+        this.productType = PatchProductType.getValueByProductName(identityName);
         this.targetVersion = targetVersion;
         this.description = description;
         this.contents = contents;
@@ -79,6 +81,10 @@ public final class Patch {
 
     public String getContents() {
         return contents;
+    }
+
+    public PatchProductType getProductType() {
+        return productType;
     }
 
     @Override

--- a/modules/common/wfly-patch-parser/src/main/java/org/rhq/common/wildfly/PatchParser.java
+++ b/modules/common/wfly-patch-parser/src/main/java/org/rhq/common/wildfly/PatchParser.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -44,7 +46,8 @@ import javax.xml.stream.XMLStreamReader;
  */
 public final class PatchParser {
     private static final String PATCHES_NAMESPACE_URI = "urn:jboss:patch:bundle:1.0";
-    private static final String PATCH_NAMESPACE_URI = "urn:jboss:patch:1.0";
+    private static final String PATCH_NAMESPACE_URI_REGEXP = "urn:jboss:patch:1[.][012]";
+    private static final Pattern NAMESPACE_PATTERN = Pattern.compile(PATCH_NAMESPACE_URI_REGEXP);
 
     private PatchParser() {
 
@@ -190,16 +193,15 @@ public final class PatchParser {
                     continue;
                 }
 
+                QName name = rdr.getName();
                 if (!foundPatch) {
                     if (foundElements) {
                         throw new IllegalArgumentException("Not a Wildfly patch");
                     }
-                    String namespace = rdr.getName().getNamespaceURI();
-                    foundPatch = PATCH_NAMESPACE_URI.equals(namespace) && "patch".equals(rdr.getName().getLocalPart());
+                    foundPatch = NAMESPACE_PATTERN.matcher(name.getNamespaceURI()).matches() && "patch".equals(name.getLocalPart());
                     patchId = getAttributeValue(rdr, "", "id");
                 } else {
-                    QName name = rdr.getName();
-                    if (PATCH_NAMESPACE_URI.equals(name.getNamespaceURI())) {
+                    if (NAMESPACE_PATTERN.matcher(name.getNamespaceURI()).matches()) {
                         if ("upgrade".equals(name.getLocalPart())) {
                             patchType = Patch.Type.CUMULATIVE;
                             identityName = getAttributeValue(rdr, "", "name");

--- a/modules/common/wfly-patch-parser/src/main/java/org/rhq/common/wildfly/PatchProductType.java
+++ b/modules/common/wfly-patch-parser/src/main/java/org/rhq/common/wildfly/PatchProductType.java
@@ -1,0 +1,66 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2016 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+package org.rhq.common.wildfly;
+
+/**
+ * Simplified and combined version of JBossProductType as defined in the jboss-as-7 and wfly-10 agent plugins
+ *
+ * @author Michael Burman
+ */
+public enum PatchProductType {
+
+    EAP("EAP", "JBoss EAP 6", "JBoss Enterprise Application Platform 6", "EAP"),
+    EAP7("EAP", "EAP 7", "JBoss Enterprise Application Platform 7", "JBoss EAP"),
+    ISPN("ISPN", "Infinispan Server", "Infinispan Server", "Infinispan Server"),
+    JDG("JDG", "JBoss JDG 6", "JBoss Data Grid 6", "Data Grid"),
+    JPP("JPP", "JBoss JPP 6", "JBoss Portal Platform 6", "Portal Platform"),
+    SOA("SOA-P", "JBoss SOA-P 6", "Red Hat JBoss Fuse Service Works", "Red Hat JBoss Fuse Service Works"),
+    BRMS("BRMS", "JBoss BRMS", "Red Hat JBoss BRMS", "BRMS"),
+    BPMS("BPM Suite", "JBoss BPM Suite", "Red Hat JBoss BPM Suite", "BPM Suite"),
+    JDV("JDV", "Data Virt", "Red Hat JBoss Data Virtualization", "Red Hat JBoss Data Virtualization"),
+    WILDFLY10("WildFly", "WildFly 10", "WildFly Application Server 10", "WildFly Full");
+
+    public final String SHORT_NAME;
+    public final String NAME;
+    public final String FULL_NAME;
+    /** The value the server returns for the "product-name" attribute of the root resource. */
+    public final String PRODUCT_NAME;
+
+    PatchProductType(String shortName, String name, String fullName, String productName) {
+        this.SHORT_NAME = shortName;
+        this.NAME = name;
+        this.FULL_NAME = fullName;
+        this.PRODUCT_NAME = productName;
+    }
+
+    public static PatchProductType getValueByProductName(String productName) {
+        for (PatchProductType productType : PatchProductType.values()) {
+            if (productType.PRODUCT_NAME.equals(productName)) {
+                return productType;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.NAME;
+    }
+
+}

--- a/modules/enterprise/server/plugins/pom.xml
+++ b/modules/enterprise/server/plugins/pom.xml
@@ -72,6 +72,7 @@
     <module>validate-all-serverplugins</module>
     <module>packagetype-cli</module>
     <module>wfly-patch-bundle</module>
+    <module>wfly-10-patch-bundle</module>
   </modules>
 
 </project>

--- a/modules/enterprise/server/plugins/wfly-10-patch-bundle/pom.xml
+++ b/modules/enterprise/server/plugins/wfly-10-patch-bundle/pom.xml
@@ -1,0 +1,137 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.rhq</groupId>
+        <artifactId>rhq-enterprise-server-plugins-parent</artifactId>
+        <version>4.14.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rhq-serverplugin-wfly-10-patch-bundle</artifactId>
+    <packaging>jar</packaging>
+
+    <name>RHQ Wildfly 10 Patch Bundle Server Plugin</name>
+    <description>Server side plugin that manages Wildfly 10 patch files and exposes them as RHQ bundles</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.rhq</groupId>
+            <artifactId>rhq-wfly-patch-parser</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludedGroups>${rhq.testng.excludedGroups}</excludedGroups>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-rhq-plugins</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+
+                                <artifactItem>
+                                    <groupId>org.rhq</groupId>
+                                    <artifactId>rhq-wfly-patch-parser</artifactId>
+                                    <version>${project.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.outputDirectory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>dev</id>
+
+            <properties>
+                <rhq.rootDir>../../../../..</rhq.rootDir>
+                <rhq.containerDir>${rhq.rootDir}/${rhq.devContainerServerPath}</rhq.containerDir>
+                <rhq.deploymentDir>${rhq.containerDir}/${rhq.serverPluginDir}</rhq.deploymentDir>
+            </properties>
+
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+
+                            <execution>
+                                <id>deploy</id>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${rhq.deploymentDir}" />
+                                        <property name="deployment.file" location="${rhq.deploymentDir}/${project.build.finalName}.jar" />
+                                        <echo>*** Updating ${deployment.file}...</echo>
+                                        <jar destfile="${deployment.file}" basedir="${project.build.outputDirectory}" />
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+
+                            <execution>
+                                <id>undeploy</id>
+                                <phase>clean</phase>
+                                <configuration>
+                                    <target>
+                                        <property name="deployment.file" location="${rhq.deploymentDir}/${project.build.finalName}.jar" />
+                                        <echo>*** Deleting ${deployment.file}...</echo>
+                                        <delete file="${deployment.file}" />
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+
+                            <execution>
+                                <id>deploy-jar-meta-inf</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <property name="deployment.file" location="${rhq.deploymentDir}/${project.build.finalName}.jar" />
+                                        <echo>*** Updating META-INF dir in ${deployment.file}...</echo>
+                                        <unjar src="${project.build.directory}/${project.build.finalName}.jar" dest="${project.build.outputDirectory}">
+                                            <patternset>
+                                                <include name="META-INF/**" />
+                                            </patternset>
+                                        </unjar>
+                                        <jar destfile="${deployment.file}" manifest="${project.build.outputDirectory}/META-INF/MANIFEST.MF" update="true">
+                                        </jar>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/modules/enterprise/server/plugins/wfly-10-patch-bundle/src/main/java/org/rhq/enterprise/server/plugins/wfly10patch/Wildfly10PatchBundleServerPluginComponent.java
+++ b/modules/enterprise/server/plugins/wfly-10-patch-bundle/src/main/java/org/rhq/enterprise/server/plugins/wfly10patch/Wildfly10PatchBundleServerPluginComponent.java
@@ -17,18 +17,18 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-package org.rhq.enterprise.server.plugins.wflypatch;
+package org.rhq.enterprise.server.plugins.wfly10patch;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.rhq.common.wildfly.PatchProductType;
 import org.rhq.common.wildfly.Patch;
 import org.rhq.common.wildfly.PatchBundle;
 import org.rhq.common.wildfly.PatchInfo;
 import org.rhq.common.wildfly.PatchParser;
-import org.rhq.common.wildfly.PatchProductType;
 import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
 import org.rhq.core.domain.configuration.definition.PropertyDefinitionSimple;
 import org.rhq.core.domain.configuration.definition.PropertySimpleType;
@@ -43,14 +43,15 @@ import org.rhq.enterprise.server.plugin.pc.bundle.UnknownRecipeException;
 
 /**
  * @author Lukas Krejci
+ * @author Michael Burman
  * @since 4.13
  */
-public class WildflyPatchBundleServerPluginComponent implements ServerPluginComponent, BundleServerPluginFacet {
+public class Wildfly10PatchBundleServerPluginComponent implements ServerPluginComponent, BundleServerPluginFacet {
 
     @Override
     public RecipeParseResults parseRecipe(String recipe) throws UnknownRecipeException {
         throw new UnknownRecipeException(
-            "The Wildfly patches cannot be dealt with using only recipes - the whole distribution file is needed.");
+            "The Wildfly 10 patches cannot be dealt with using only recipes - the whole distribution file is needed.");
     }
 
     @Override
@@ -76,7 +77,7 @@ public class WildflyPatchBundleServerPluginComponent implements ServerPluginComp
             if (patchInfo.is(Patch.class)) {
                 Patch patch = patchInfo.as(Patch.class);
 
-                if(PatchProductType.EAP7.equals(patch.getProductType())) {
+                if(!PatchProductType.EAP7.equals(patch.getProductType())) {
                     throw new UnknownRecipeException();
                 }
 
@@ -119,7 +120,7 @@ public class WildflyPatchBundleServerPluginComponent implements ServerPluginComp
 
                 if (lastPatch == null) {
                     throw new UnknownRecipeException("Not a Wildfly patch");
-                } else if (PatchProductType.EAP7.equals(lastPatch.getProductType())) {
+                } else if (!PatchProductType.EAP7.equals(lastPatch.getProductType())) {
                     throw new UnknownRecipeException();
                 }
 

--- a/modules/enterprise/server/plugins/wfly-10-patch-bundle/src/main/resources/META-INF/rhq-serverplugin.xml
+++ b/modules/enterprise/server/plugins/wfly-10-patch-bundle/src/main/resources/META-INF/rhq-serverplugin.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ RHQ Management Platform
+  ~ Copyright (C) 2014-2016 Red Hat, Inc.
+  ~ All rights reserved.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation version 2 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+  -->
+<bundle-plugin name="Wfly10PatchBundleServerPlugin"
+               displayName="Wildfly 10 Patch Bundle Processor"
+               description="Processes Wildfly and EAP patches as RHQ bundles"
+               package="org.rhq.enterprise.server.plugins.wfly10patch"
+               xmlns="urn:xmlns:rhq-serverplugin.bundle"
+               xmlns:serverplugin="urn:xmlns:rhq-serverplugin"
+               xmlns:c="urn:xmlns:rhq-configuration">
+
+    <serverplugin:plugin-component class="Wildfly10PatchBundleServerPluginComponent">
+    </serverplugin:plugin-component>
+
+    <bundle type="EAP7 Patch"/>
+
+</bundle-plugin>

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
@@ -223,8 +223,6 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         String description = buildDefaultResourceDescription(hostPort, productType);
         String version = getVersion(homeDir, productType);
 
-        pluginConfig.setSimpleValue("supportsPatching", Boolean.toString(true));
-
         return new DiscoveredResourceDetails(discoveryContext.getResourceType(), key, name, version, description,
             pluginConfig, process);
     }
@@ -480,7 +478,6 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
 
         pluginConfig.put(new PropertySimple("manuallyAdded", true));
         pluginConfig.put(new PropertySimple("productType", productType.name()));
-        pluginConfig.put(new PropertySimple("supportsPatching", true)); // @TODO Remove after cleaning elsewhere
         pluginConfig.setSimpleValue("expectedRuntimeProductName", productType.PRODUCT_NAME);
 
         DiscoveredResourceDetails detail = new DiscoveredResourceDetails(context.getResourceType(), key, name, version,

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseServerComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseServerComponent.java
@@ -1008,15 +1008,6 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
                     val = getStringValue(props.get(realName));
                 }
 
-                if ("null".equals(val)) {
-                    if (realName.equals("product-name"))
-                        val = "JBoss AS";
-                    else if (realName.equals("product-version"))
-                        val = getStringValue(props.get("release-version"));
-                    else if (LOG.isDebugEnabled()) {
-                        LOG.debug("Value for " + realName + " was 'null' and no replacement found");
-                    }
-                }
                 MeasurementDataTrait data = new MeasurementDataTrait(request, val);
                 report.addData(data);
             }
@@ -1072,9 +1063,6 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
     }
 
     protected String collectPatches() {
-
-        JBossProductType productType = serverPluginConfig.getProductType();
-
         String cliCommand = "patch info --json-output";
 
         ProcessExecutionResults results = ServerControl.onServer(context.getPluginConfiguration(), getMode(),

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/patching/PatchHandlerComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/patching/PatchHandlerComponent.java
@@ -610,18 +610,6 @@ public final class PatchHandlerComponent implements ResourceComponent<ResourceCo
     private Result<Void> sanityCheck(ServerControl serverControl, Configuration referencedConfiguration,
         BundleManagerProvider bmp, BundleResourceDeployment resourceDeployment, boolean uniqueDeploymentRequired) {
 
-        //check if patching is supported
-
-        PropertySimple supportsPatching = referencedConfiguration.getSimple("supportsPatching");
-
-        if (supportsPatching == null) {
-            return Result.error("Target resource doesn't contain the 'Supports Patching' property in its connection settings. Using an old version of the JBossAS7 plugin?");
-        }
-
-        if (supportsPatching.getBooleanValue() == null || !supportsPatching.getBooleanValue()) {
-            return Result.error("The target resource does not support patching.");
-        }
-
         ProcessExecutionResults results = serverControl.cli().disconnected(true).executeCliCommand("help --commands");
         switch (handleExecutionResults(results, bmp, resourceDeployment, false)) {
         case EXECUTION_ERROR:

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/patching/PatchHandlerDiscoveryComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/patching/PatchHandlerDiscoveryComponent.java
@@ -37,8 +37,8 @@ public final class PatchHandlerDiscoveryComponent implements ResourceDiscoveryCo
     public Set<DiscoveredResourceDetails> discoverResources(ResourceDiscoveryContext<ResourceComponent<?>> context) {
 
         Configuration pluginConfig = context.getDefaultPluginConfiguration();
-        DiscoveredResourceDetails details = new DiscoveredResourceDetails(context.getResourceType(), "WflyPatchHandler",
-            "Wildfly/JBoss EAP Patch Handler", null, null, pluginConfig, null);
+        DiscoveredResourceDetails details = new DiscoveredResourceDetails(context.getResourceType(), "Wildfly10PatchHandler",
+            "Wildfly 10/EAP 7 Patch Handler", null, null, pluginConfig, null);
 
         return Collections.singleton(details);
     }

--- a/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
@@ -1118,14 +1118,6 @@
       <c:simple-property name="logDir" type="file" description="the directory where log files will be written for this host controller" displayName="Log Directory" readOnly="true" required="false"/>
       <c:simple-property name="domainHost" type="string" readOnly="true" required="false" description="Host name within the AS7 domain (Deprecated, use 'name' trait)"/>
       <c:simple-property name="productType" type="string" readOnly="true" required="false" description="Server product type (e.g. AS or EAP)"/>
-        <c:simple-property name="supportsPatching" type="boolean" readOnly="false" required="true"
-                           default="__UNINITIALIZED_VALUE__(should be replaced by agent automatically)">
-            <c:description>
-                Whether this EAP server supports patching. This should be automatically deduced by the agent. It is highly
-                recommended to leave this with the discovered value. However, you will need to manually update this value
-                if you manually upgrade your server from a version that does not support patching to a version that does.
-            </c:description>
-        </c:simple-property>
 
       &startScriptPluginConfigGroup;
       &logSources;
@@ -1502,14 +1494,6 @@
       <c:simple-property name="configDir" type="file" description="Base configuration directory" displayName="Configuration Directory" readOnly="true" required="false"/>
       <c:simple-property name="logDir" type="file" description="the directory where log files will be written for this server" displayName="Log Directory" readOnly="true" required="false"/>
       <c:simple-property name="productType" type="string" readOnly="true" required="false" description="Server product type (e.g. AS or EAP)"/>
-      <c:simple-property name="supportsPatching" type="boolean" readOnly="false" required="true"
-                         default="__UNINITIALIZED_VALUE__(should be replaced by agent automatically)">
-        <c:description>
-          Whether this EAP server supports patching. This should be automatically deduced by the agent. It is highly
-          recommended to leave this with the discovered value. However, you will need to manually update this value
-          if you manually upgrade your server from a version that does not support patching to a version that does.
-        </c:description>
-      </c:simple-property>
 
       <c:group name="operations">
         <c:simple-property name="startScript" displayName="Start Script Path" type="file" required="false">
@@ -16163,7 +16147,7 @@
   </service>
 
 
-  <service name="Wildfly/JBoss EAP Patch Handler"
+  <service name="Wildfly 10/EAP 7 Patch Handler"
            discovery="org.rhq.modules.plugins.wildfly10.patching.PatchHandlerDiscoveryComponent"
            class="org.rhq.modules.plugins.wildfly10.patching.PatchHandlerComponent"
            singleton="true"


### PR DESCRIPTION
This is still work in progress (requires couple of extra steps to patching process). Adds support for EAP7 instance patching and adds a new server-plugin for EAP7 patching. Checks for product type of the given patch and fixes also EAP6 patching to allow using namespace 1.1 on EAP6.