### PR TITLE
Bug 1312847 - Report "Suspect Metrics" is empty for user in "All Resources" role

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/measurement/MeasurementOOBManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/measurement/MeasurementOOBManagerBean.java
@@ -393,7 +393,8 @@ public class MeasurementOOBManagerBean implements MeasurementOOBManagerLocal {
 
         pc.initDefaultOrderingField("o.oobFactor", PageOrdering.DESC);
 
-        boolean isAdmin = authMangager.isOverlord(subject) || authMangager.isSystemSuperuser(subject);
+        boolean isAdmin = authMangager.isOverlord(subject) || authMangager.isSystemSuperuser(subject)
+            || authMangager.isInventoryManager(subject);
 
         String queryName = isAdmin ? MeasurementOOB.GET_SCHEDULES_WITH_OOB_AGGREGATE_ADMIN
             : MeasurementOOB.GET_SCHEDULES_WITH_OOB_AGGREGATE;


### PR DESCRIPTION
I assume that if you have permissions to manage the inventory, you should see all resources and all groups and skip the role-group validation for suspect metric report.