### PR TITLE
Bug 1321069 - EAP7 - Undertow - Impossible to add new buffer cache.

### DIFF
--- a/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
@@ -8999,7 +8999,8 @@
 
     <service name="Buffer Cache"
              discovery="SubsystemDiscovery"
-             class="BaseComponent">
+             class="BaseComponent"
+             createDeletePolicy="both">
 
       <plugin-configuration>
         <c:simple-property name="path" readOnly="true" default="buffer-cache"/>


### PR DESCRIPTION
  Updated the xml to allow Buffer Cache creation.