### PR TITLE
Bug 1314388 - Do not load max-pool-size when derive-size is set.

### DIFF
--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/Ejb3Component.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/Ejb3Component.java
@@ -43,10 +43,13 @@ public class Ejb3Component extends BaseComponent<BaseComponent<?>> {
 
         CompositeOperation cop = new CompositeOperation();
 
-        if((derive == null || derive.getStringValue() == null) && maxPoolSize != null) {
+        boolean deriveIsNull = (derive == null || derive.getStringValue() == null);
+        boolean maxPoolSizeIsNull = (maxPoolSize == null || maxPoolSize.getIntegerValue() == null);
+
+        if (deriveIsNull && !maxPoolSizeIsNull) {
             cop.addStep(new UndefineAttribute(address, DERIVE_ATTRIBUTE));
             cop.addStep(new WriteAttribute(address, MAX_POOL_SIZE, config.getSimpleValue(MAX_POOL_SIZE)));
-        } else if(derive != null && (maxPoolSize == null || maxPoolSize.getStringValue() == null)) {
+        } else if (!deriveIsNull && maxPoolSizeIsNull) {
             cop.addStep(new UndefineAttribute(address, MAX_POOL_SIZE));
             cop.addStep(new WriteAttribute(address, DERIVE_ATTRIBUTE, config.getSimpleValue(DERIVE_ATTRIBUTE)));
         } else {
@@ -80,6 +83,11 @@ public class Ejb3Component extends BaseComponent<BaseComponent<?>> {
         if(derive != null && "none".equals(derive.getStringValue())) {
             derive.setValue(null);
         }
+
+        if (derive != null && derive.getStringValue() != null) {
+            configuration.remove(MAX_POOL_SIZE);
+        }
+
         return configuration;
     }
 }

--- a/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
@@ -3727,7 +3727,7 @@
               <c:option value="from-worker-pools" name="from-worker-pools"/>
             </c:property-options>
           </c:simple-property>
-          <c:simple-property name="max-pool-size" required="false" type="string" readOnly="false" defaultValue="20" description="The maximum number of bean instances that the pool can hold at a given point in time. The default value is 20."/>
+          <c:simple-property name="max-pool-size" required="false" type="string" readOnly="false" description="The maximum number of bean instances that the pool can hold at a given point in time."/>
           <c:simple-property name="timeout" required="false" type="string" readOnly="false" defaultValue="5" description="The maximum amount of time to wait for a bean instance to be available from the pool. The default value is 5."/>
           <c:simple-property name="timeout-unit" required="false" type="string" readOnly="false" defaultValue="MINUTES" description="The instance acquisition timeout unit. The default value is MINUTES.">
             <c:property-options>
@@ -7536,7 +7536,7 @@
               <c:option value="from-worker-pools" name="from-worker-pools"/>
             </c:property-options>
           </c:simple-property>
-          <c:simple-property name="max-pool-size" required="false" type="string" readOnly="false" defaultValue="20" description="The maximum number of bean instances that the pool can hold at a given point in time. The default value is 20."/>
+          <c:simple-property name="max-pool-size" required="false" type="string" readOnly="false" description="The maximum number of bean instances that the pool can hold at a given point in time."/>
           <c:simple-property name="timeout" required="false" type="string" readOnly="false" defaultValue="5" description="The maximum amount of time to wait for a bean instance to be available from the pool. The default value is 5."/>
           <c:simple-property name="timeout-unit" required="false" type="string" readOnly="false" defaultValue="MINUTES" description="The instance acquisition timeout unit. The default value is MINUTES.">
             <c:property-options>
@@ -13130,7 +13130,7 @@
             <c:option value="from-worker-pools" name="from-worker-pools"/>
           </c:property-options>
         </c:simple-property>
-        <c:simple-property name="max-pool-size" required="false" type="string" readOnly="false" defaultValue="20" description="The maximum number of bean instances that the pool can hold at a given point in time. The default value is 20."/>
+        <c:simple-property name="max-pool-size" required="false" type="string" readOnly="false" description="The maximum number of bean instances that the pool can hold at a given point in time."/>
         <c:simple-property name="timeout" required="false" type="string" readOnly="false" defaultValue="5" description="The maximum amount of time to wait for a bean instance to be available from the pool. The default value is 5."/>
         <c:simple-property name="timeout-unit" required="false" type="string" readOnly="false" defaultValue="MINUTES" description="The instance acquisition timeout unit. The default value is MINUTES.">
           <c:property-options>


### PR DESCRIPTION
max-pool-size takes the default value, even when is undefined, making it harder for the user to update the configuration as it can't be set along with derive-size.

> 1) Set derive-size and unset max-pool-size
> 2) Save
> 3) Change something else (Timeout or Timeout Unit)
> 4) Save