### PR TITLE
Bug 1311140 - EAP7 - missing rt filter modules for eap7

### DIFF
--- a/modules/enterprise/server/appserver/src/main/scripts/rhq-container.build.xml
+++ b/modules/enterprise/server/appserver/src/main/scripts/rhq-container.build.xml
@@ -568,8 +568,8 @@ checkIfRunning(16);]]>
               tofile="${rhq.ear.dir}/rhq-downloads/connectors/rhq-rtfilter-subsystem-module.zip" />
 
         <copy
-              file="${settings.localRepository}/org/rhq/helpers/rhq-rtfilter-wfly-10-subsystem/${rhq-rtfilter-wfly-10-subsystem.version}/rhq-rtfilter-wfly-10-subsystem-${rhq-rtfilter-wfly-10-subsystem.version}.zip"
-              tofile="${rhq.ear.dir}/rhq-downloads/connectors/rhq-rtfilter-wfly-10-subsystem-module.zip"/>
+              file="${settings.localRepository}/org/rhq/helpers/rhq-rtfilter-wfly-10-dist/${rhq-rtfilter-wfly-10-dist.version}/rhq-rtfilter-wfly-10-dist-${rhq-rtfilter-wfly-10-dist.version}.zip"
+              tofile="${rhq.ear.dir}/rhq-downloads/connectors/rhq-rtfilter-wfly-10-dist.zip"/>
     </target>
 
     <target name="prepare-bin-dir">

--- a/modules/helpers/pom.xml
+++ b/modules/helpers/pom.xml
@@ -21,6 +21,7 @@
     <module>rtfilter</module>
     <module>rtfilter-subsystem</module>
     <module>rtfilter-wfly-10-subsystem</module>
+    <module>rtfilter-wfly-10-dist</module>
     <module>bundleGen</module>
     <module>jeeGen</module>
     <module>perftest-support</module>

--- a/modules/helpers/rtfilter-wfly-10-dist/pom.xml
+++ b/modules/helpers/rtfilter-wfly-10-dist/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ RHQ Management Platform
+  ~ Copyright 2016, Red Hat Middleware LLC, and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation version 2 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along
+  ~ with this program; if not, write to the Free Software Foundation, Inc.,
+  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.rhq.helpers</groupId>
+    <artifactId>rhq-helpers</artifactId>
+    <version>4.14.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>rhq-rtfilter-wfly-10-dist</artifactId>
+  <packaging>pom</packaging>
+
+  <name>RHQ Response-Time Filter Distribution for Wildfly 10</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.rhq.helpers</groupId>
+      <artifactId>rhq-rtfilter</artifactId>
+      <version>${project.version}</version>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.rhq.helpers</groupId>
+      <artifactId>rhq-rtfilter-wfly-10-subsystem</artifactId>
+      <version>${project.version}</version>
+      <type>zip</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>src/main/scripts/assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>module-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/modules/helpers/rtfilter-wfly-10-dist/src/main/scripts/assembly.xml
+++ b/modules/helpers/rtfilter-wfly-10-dist/src/main/scripts/assembly.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ RHQ Management Platform
+  ~ Copyright 2016, Red Hat Middleware LLC, and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation version 2 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along
+  ~ with this program; if not, write to the Free Software Foundation, Inc.,
+  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+  -->
+
+<assembly>
+  <id>dist-assembly</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <unpack>true</unpack>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,7 @@
     <rest-docs-generator.version>${rhq.pom.version}</rest-docs-generator.version>
     <rhq-rtfilter-subsystem.version>${rhq.pom.version}</rhq-rtfilter-subsystem.version>
     <rhq-rtfilter-wfly-10-subsystem.version>${rhq.pom.version}</rhq-rtfilter-wfly-10-subsystem.version>
+    <rhq-rtfilter-wfly-10-dist.version>${rhq.pom.version}</rhq-rtfilter-wfly-10-dist.version>
     <rhq-aliases-plugin.version>${rhq.pom.version}</rhq-aliases-plugin.version>
     <rhq-ant-bundle-plugin.version>${rhq.pom.version}</rhq-ant-bundle-plugin.version>
     <rhq-apache-plugin.version>${rhq.pom.version}</rhq-apache-plugin.version>


### PR DESCRIPTION
Added a new module which produces a single zip with both modules inside.
The zip file name is 'rhq-rtfilter-wfly-10-dist.zip'.