### PR TITLE
Bug 1323332 - Orphaned configuration left in database

### DIFF
--- a/modules/enterprise/server/itests-2/src/test/java/org/rhq/enterprise/server/drift/DriftManagerBeanTest.java
+++ b/modules/enterprise/server/itests-2/src/test/java/org/rhq/enterprise/server/drift/DriftManagerBeanTest.java
@@ -64,7 +64,7 @@ import org.rhq.enterprise.server.util.LookupUtil;
 
 /**
  * Test for {@link DriftManagerBean} SLSB.
- * 
+ *
  * !!! Actually, this is really testing only the JPA impl, it does not actually go through the
  * !!! configured drift server plugin.  To enhance this to do that then you may need to model this
  * !!! mode like BundleManagerBeanTest
@@ -97,6 +97,7 @@ public class DriftManagerBeanTest extends AbstractEJB3Test {
         DriftServerPluginService driftServerPluginService = new DriftServerPluginService(getTempDir());
         prepareCustomServerPluginService(driftServerPluginService);
         driftServerPluginService.masterConfig.getPluginDirectory().mkdirs();
+        driftServerPluginService.startMasterPluginContainer();
 
         deleteDriftFiles();
 

--- a/modules/enterprise/server/itests-2/src/test/java/org/rhq/enterprise/server/drift/ManageDriftDefinitionsTest.java
+++ b/modules/enterprise/server/itests-2/src/test/java/org/rhq/enterprise/server/drift/ManageDriftDefinitionsTest.java
@@ -20,6 +20,7 @@
 package org.rhq.enterprise.server.drift;
 
 import static java.util.Arrays.asList;
+
 import static org.rhq.core.domain.drift.DriftCategory.FILE_ADDED;
 import static org.rhq.core.domain.drift.DriftChangeSetCategory.COVERAGE;
 import static org.rhq.core.domain.drift.DriftConfigurationDefinition.BaseDirValueContext.fileSystem;
@@ -34,8 +35,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.persistence.EntityManager;
-
-import org.testng.annotations.Test;
 
 import org.rhq.core.domain.common.EntityContext;
 import org.rhq.core.domain.configuration.Configuration;
@@ -60,6 +59,7 @@ import org.rhq.enterprise.server.safeinvoker.HibernateDetachUtility;
 import org.rhq.enterprise.server.safeinvoker.HibernateDetachUtility.SerializationType;
 import org.rhq.enterprise.server.test.TransactionCallback;
 import org.rhq.test.AssertUtils;
+import org.testng.annotations.Test;
 
 @Test
 public class ManageDriftDefinitionsTest extends AbstractDriftServerTest {
@@ -88,8 +88,8 @@ public class ManageDriftDefinitionsTest extends AbstractDriftServerTest {
     protected void purgeDB() {
         super.purgeDB();
 
-        deleteEntity(Resource.class, DRIFT_NOT_SUPPORTED_RESOURCE);
-        deleteEntity(ResourceType.class, DRIFT_NOT_SUPPORTED_TYPE);
+        removeEntity(Resource.class, DRIFT_NOT_SUPPORTED_RESOURCE);
+        removeEntity(ResourceType.class, DRIFT_NOT_SUPPORTED_TYPE);
     }
 
     public void createDefinitionFromUnpinnedTemplate() throws Exception {

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/alert/AlertDefinitionManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/alert/AlertDefinitionManagerBean.java
@@ -816,12 +816,8 @@ public class AlertDefinitionManagerBean implements AlertDefinitionManagerLocal, 
             if (alertConditionCategory == AlertConditionCategory.BASELINE) {
 
                 MeasurementDefinition def = alertCondition.getMeasurementDefinition();
-                def = entityManager.getReference(MeasurementDefinition.class, def.getId());
+                def = entityManager.find(MeasurementDefinition.class, def.getId());
                 NumericType numType = def.getNumericType();
-                if (numType == null) {
-                    def = entityManager.getReference(MeasurementDefinition.class, def.getId());
-                    numType = def.getNumericType();
-                }
                 if (numType != NumericType.DYNAMIC) {
                     throw new InvalidAlertDefinitionException("Invalid Condition: '" + def.getDisplayName()
                         + "' is a trending metric, and thus will never have baselines calculated for it.");

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/ConfigurationManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/ConfigurationManagerBean.java
@@ -410,7 +410,7 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
             LOG.debug("Getting current Resource configuration for Resource [" + resourceId + "]...");
         }
 
-        Resource resource = entityManager.getReference(Resource.class, resourceId);
+        Resource resource = entityManager.find(Resource.class, resourceId);
         if (resource == null) {
             throw new NoResultException("Cannot get latest resource configuration for unknown Resource [" + resourceId
                 + "].");
@@ -553,7 +553,7 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
             LOG.debug("Getting current plugin configuration for resource [" + resourceId + "]...");
         }
 
-        Resource resource = entityManager.getReference(Resource.class, resourceId);
+        Resource resource = entityManager.find(Resource.class, resourceId);
         if (resource == null) {
             throw new NoResultException("Cannot get latest plugin configuration for unknown Resource [" + resourceId
                 + "].");

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/metadata/ConfigurationMetadataManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/metadata/ConfigurationMetadataManagerBean.java
@@ -359,7 +359,7 @@ public class ConfigurationMetadataManagerBean implements ConfigurationMetadataMa
                 for (String doomedKey : doomedKeys) {
                     PropertyDefinition doomed = existingPropDefs.get(doomedKey);
                     existingPropDefs.remove(doomedKey);
-                    entityManager.remove(entityManager.getReference(PropertyDefinition.class, doomed.getId()));
+                    entityManager.remove(entityManager.find(PropertyDefinition.class, doomed.getId()));
                 }
 
                 int order = 0;

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/content/ContentSourceManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/content/ContentSourceManagerBean.java
@@ -445,7 +445,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
     public void deleteContentSourceSyncResults(Subject subject, int[] ids) {
         if (ids != null) {
             for (int id : ids) {
-                ContentSourceSyncResults doomed = entityManager.getReference(ContentSourceSyncResults.class, id);
+                ContentSourceSyncResults doomed = entityManager.find(ContentSourceSyncResults.class, id);
                 entityManager.remove(doomed);
             }
         }
@@ -479,7 +479,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
         }
 
         obfuscatePasswords(contentSource);
-        
+
         entityManager.persist(contentSource);
         // these aren't cascaded during persist, but I want to set them to null anyway, just to be sure
         contentSource.setSyncResults(null);
@@ -487,15 +487,15 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
         log.debug("User [" + subject + "] created content source [" + contentSource + "]");
         return contentSource; // now has the ID set
     }
-    
+
     @RequiredPermission(Permission.MANAGE_REPOSITORIES)
     public ContentSource simpleCreateContentSource(Subject subject, ContentSource contentSource)
         throws ContentSourceException {
         validateContentSource(contentSource);
         contentSource.setSyncResults(new ArrayList<ContentSourceSyncResults>());
-        
+
         obfuscatePasswords(contentSource);
-        
+
         entityManager.persist(contentSource);
         return contentSource;
     }
@@ -509,7 +509,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
         ContentSource loaded = entityManager.find(ContentSource.class, contentSource.getId());
 
         obfuscatePasswords(contentSource);
-                
+
         if (contentSource.getConfiguration() == null) {
             // this is a one-to-one and hibernate can't auto delete this orphan (HHH-2608), we manually do it here
             if (loaded.getConfiguration() != null) {
@@ -981,7 +981,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
      * on a Lob unless the entity class is instrumented. We can't usethat approach because it introduces
      * hibernate imports into the domain class, and that violates our restriction of exposing hibernate
      * classes to the Agent and Remote clients.
-     * 
+     *
      * @return
      */
     private PackageBits createPackageBits(boolean initialize) {
@@ -1075,7 +1075,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
         return null;
     }
 
-    // TODO: Just noticing that this method seems pretty redundant with 
+    // TODO: Just noticing that this method seems pretty redundant with
     //       downloadPackageBits(Subject subject, PackageVersionContentSource pvcs) and should probably be
     //       refactored.  Also *** the transactional decls below are not being honored because the method
     //       is not being called through the Local, so not establishing a new transactional context.
@@ -1619,7 +1619,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
                     }
                 } else {
                     rt = knownResourceTypes.get(rt);
-                }                
+                }
             }
 
             // find the new package's type (package types should already exist, agent plugin descriptors define them)
@@ -1632,7 +1632,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
                 } else {
                     q = entityManager.createNamedQuery(PackageType.QUERY_FIND_BY_NAME_AND_NULL_RESOURCE_TYPE);
                 }
-                
+
                 q.setParameter("name", pt.getName());
 
                 try {
@@ -1746,7 +1746,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
             // the check for null resource type shouldn't be necessary here because
             // the package shouldn't declare any resource versions if it doesn't declare a resource type.
             // Nevertheless, let's make that check just to prevent disasters caused by "malicious" content
-            // providers.                        
+            // providers.
             if (resourceVersions != null && rt != null) {
                 Map<String, ProductVersion> cachedProductVersions = knownProductVersions.get(rt); // we are guaranteed that this returns non-null
                 for (String version : resourceVersions) {
@@ -2510,7 +2510,7 @@ public class ContentSourceManagerBean implements ContentSourceManagerLocal {
             ContentSourceType attachedContentSourceType = getContentSourceType(contentSource.getContentSourceType().getName());
             configurationDefinition = attachedContentSourceType.getContentSourceConfigurationDefinition();
         }
-        
+
         PasswordObfuscationUtility.obfuscatePasswords(configurationDefinition, contentSource.getConfiguration());
     }
 }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/drift/DriftTemplateManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/drift/DriftTemplateManagerBean.java
@@ -20,6 +20,7 @@
 package org.rhq.enterprise.server.drift;
 
 import static javax.ejb.TransactionAttributeType.NEVER;
+
 import static org.rhq.core.domain.common.EntityContext.forResource;
 import static org.rhq.core.domain.drift.DriftChangeSetCategory.COVERAGE;
 import static org.rhq.core.domain.drift.DriftConfigurationDefinition.DriftHandlingMode.normal;
@@ -218,6 +219,7 @@ public class DriftTemplateManagerBean implements DriftTemplateManagerLocal, Drif
             throw new IllegalArgumentException("The template's base directory and filters cannot be modified");
         }
 
+        entityMgr.remove(template.getTemplateDefinition());
         template.setTemplateDefinition(updatedTemplate.getTemplateDefinition());
         template = entityMgr.merge(template);
         DriftDefinition templateDef = template.getTemplateDefinition();

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/plugin/ServerPluginManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/plugin/ServerPluginManagerBean.java
@@ -239,7 +239,7 @@ public class ServerPluginManagerBean implements ServerPluginManagerLocal, Server
         for (Integer pluginId : pluginIds) {
             ServerPlugin plugin = null;
             try {
-                plugin = entityManager.getReference(ServerPlugin.class, pluginId);
+                plugin = entityManager.find(ServerPlugin.class, pluginId);
             } catch (Exception e) {
                 log.debug("Cannot enable plugin [" + pluginId + "]. Cause: " + ThrowableUtil.getAllMessages(e));
             }
@@ -264,7 +264,7 @@ public class ServerPluginManagerBean implements ServerPluginManagerLocal, Server
     }
 
     /**
-     * checks if plugin configuration has set all required properties 
+     * checks if plugin configuration has set all required properties
      * @param plugin
      * @throws PluginConfigurationRequiredException if plugin is missing required configuration
      * @throws Exception in case of any other error
@@ -326,7 +326,7 @@ public class ServerPluginManagerBean implements ServerPluginManagerLocal, Server
 
             ServerPlugin plugin = null;
             try {
-                plugin = entityManager.getReference(ServerPlugin.class, pluginId);
+                plugin = entityManager.find(ServerPlugin.class, pluginId);
             } catch (Exception e) {
                 log.debug("Cannot disable plugin [" + pluginId + "]. Cause: " + ThrowableUtil.getAllMessages(e));
             }
@@ -381,7 +381,7 @@ public class ServerPluginManagerBean implements ServerPluginManagerLocal, Server
 
             ServerPlugin plugin = null;
             try {
-                plugin = entityManager.getReference(ServerPlugin.class, pluginId);
+                plugin = entityManager.find(ServerPlugin.class, pluginId);
             } catch (Exception e) {
                 log.debug("Cannot undeploy plugin [" + pluginId + "]. Cause: " + ThrowableUtil.getAllMessages(e));
             }

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/group/definition/GroupDefinitionManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/group/definition/GroupDefinitionManagerBean.java
@@ -555,7 +555,7 @@ public class GroupDefinitionManagerBean implements GroupDefinitionManagerLocal, 
     public void removeManagedResource_helper(Subject overlord, int groupDefinitionId, Integer doomedGroupId)
         throws GroupDefinitionDeleteException, GroupDefinitionNotFoundException {
         GroupDefinition groupDefinition = getById(groupDefinitionId);
-        ResourceGroup doomedGroup = entityManager.getReference(ResourceGroup.class, doomedGroupId);
+        ResourceGroup doomedGroup = entityManager.find(ResourceGroup.class, doomedGroupId);
         groupDefinition.removeResourceGroup(doomedGroup);
 
         try {

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/metadata/ResourceMetadataManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/resource/metadata/ResourceMetadataManagerBean.java
@@ -39,9 +39,7 @@ import javax.persistence.Query;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.jboss.ejb3.annotation.TransactionTimeout;
-
 import org.rhq.core.clientapi.agent.metadata.PluginMetadataManager;
 import org.rhq.core.domain.auth.Subject;
 import org.rhq.core.domain.authz.Permission;
@@ -480,6 +478,7 @@ public class ResourceMetadataManagerBean implements ResourceMetadataManagerLocal
                     boolean noDirChanges = (0 == dirComp.compare(existingDef, newDef));
 
                     if ((noAttachedDefs && notPinned) || noDirChanges) {
+                        entityManager.remove(existingTemplate.getConfiguration()); // don't orphan the config
                         existingTemplate.setTemplateDefinition(newDef);
 
                     } else {


### PR DESCRIPTION
We knew from observation that drift-related configs were being orphaned in
the DB.  Running some i-tests showed backing configs for drift definitions
being orphaned. This addresses a few different causes:
- improper use of EntityManager.getReference()
  - This method is basically an optimized version of EntityManager.find(),
    with the difference being that it is not required to go to the DB, and
    instead basically wraps the given ID in a proxy for the desired class.
    It should generally not be used for reasons outside of using the proxy
    to set FK references in other entities, or to explicitly call setters
    on the proxy in some circumstances.  It should not be used for an
    existence check, a way to perform subsequent gets on the proxy, or
    passed to EntityManager.remove(). We were violating all of these rules
    in various places.  The calls to EM.remove were the cause of some
    orphaned config because the getReference proxy did not provide the
    proxy necessary for EM.remove to provide the cascade delete.
- improper update of a DriftDefinition or DriftDefinitionTemplate
  - When updating these entities we were not removing the old backing
    config, or backing drift definition for a template, when replacing
    it with the new one.
- improper test cleanup
  - this would not affect production. We were directly deleting
    DriftDefinition and DriftDefinitionTemplate, so the cascade delete
    was not happening. By changing the cleanup code to use EM.remove() the
    configs are now cleaned up properly.

Note that this commit does not guarantee to solve this BZ entirely or
even partially, but it is guaranteed to stop some orphan issues, as proven
in testing.  Also, it includes analogous changes outside of the drift domain.