### PR TITLE
Fixing the NPE in the UI when adding or creating a user.

### DIFF
--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/admin/users/UserEditView.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/admin/users/UserEditView.java
@@ -471,6 +471,12 @@ public class UserEditView extends AbstractRecordEditor<UsersDataSource> {
 
     @Override
     protected void postSaveAction() {
+        Subject sessionSubject = UserSessionManager.getSessionSubject();
+        boolean userBeingEditedIsLoggedInUser = (getRecordId() == sessionSubject.getId());
+
+        if (!userBeingEditedIsLoggedInUser) {
+            return;
+        }
         List<Integer> currentState = getIntegerList();
         if (!initialState.equals(currentState)) {
             prefs.setShowUiSubsystems(currentState, new AsyncCallback<Subject>() {


### PR DESCRIPTION
The `uiCustomizationGrid` was null when creating new user or editing a user that wasn't logged in. This is because the show/hide subsystem configuration is available only to those users that are logged in.

That led to NPE when calling `uiCustomizationGrid.getRecords()` in the post save action that called `getIntegerList()`.