### PR TITLE
Bug 1186300 - java.lang.IllegalArgumentException:Invalid column width…

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/dashboard/DashboardManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/dashboard/DashboardManagerBean.java
@@ -96,6 +96,10 @@ public class DashboardManagerBean implements DashboardManagerLocal, DashboardMan
                 && d.getOwner().getId() != subject.getId()) {
                 throw new PermissionException("You may only alter dashboards you own.");
             }
+            // Remove orphaned configuration
+            if (d.getConfiguration().getId() != dashboard.getConfiguration().getId()) {
+                entityManager.remove(d.getConfiguration());
+            }
             return entityManager.merge(dashboard);
         }
     }


### PR DESCRIPTION
…s (more widths than columns) [58%, *] error thrown in JBoss ON UI

 Property 'width' was duplicated for configuration's dashboards. These duplicated values may
 yield the error when the incorrect 'width' is selected (I guess that the lower id is selected).
 I couldn't reproduce this bug on any way and couldn't find any way for it to happen on the code.
 I propose a "fix when it happens".

 When detecting more widths than columns, trim the additional widths and attach fresh Configuration
 with the same Properties as the current Property (this deletes duplicates in case they exist).
 On server-side, old configuration is deleted.