### PR TITLE
Bug 1205429 - Platform's file system resources are blacklisted and al…

### DIFF
--- a/modules/core/native-system/intentional-api-changes-since-4.13.0.xml
+++ b/modules/core/native-system/intentional-api-changes-since-4.13.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  ~ RHQ Management Platform
+  ~ Copyright (C) 2005-2014 Red Hat, Inc.
+  ~ All rights reserved.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation version 2 of the License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software Foundation, Inc.,
+  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+  -->
+
+<differences>
+  <difference>
+    <className>org/rhq/core/system/SystemInfo</className>
+    <differenceType>7012</differenceType>  <!-- method added to an interface -->
+    <method>java.util.List getFileSystemsDeferredUsageInfo()</method>
+    <justification>BZ 1205429 - Adding a method to deferred the fetch of file system usage info for the FileSystemInfo objects.</justification>
+  </difference>
+</differences>

--- a/modules/core/native-system/src/main/java/org/rhq/core/system/JavaSystemInfo.java
+++ b/modules/core/native-system/src/main/java/org/rhq/core/system/JavaSystemInfo.java
@@ -291,6 +291,16 @@ public class JavaSystemInfo implements SystemInfo {
     /**
      * Throws {@link UnsupportedOperationException} since the Java API cannot obtain information about file systems.
      *
+     * @see SystemInfo#getFileSystemsDeferredUsageInfo()
+     */
+    public List<FileSystemInfo> getFileSystemsDeferredUsageInfo() {
+        throw getUnsupportedException("Cannot get file systems information");
+
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException} since the Java API cannot obtain information about file systems.
+     *
      * @see SystemInfo#getFileSystem(String)
      */
     public FileSystemInfo getFileSystem(String directory) {

--- a/modules/core/native-system/src/main/java/org/rhq/core/system/NativeSystemInfo.java
+++ b/modules/core/native-system/src/main/java/org/rhq/core/system/NativeSystemInfo.java
@@ -310,7 +310,7 @@ public class NativeSystemInfo implements SystemInfo {
         return new CpuInformation(cpuIndex, sigar);
     }
 
-    public List<FileSystemInfo> getFileSystems() {
+    private List<FileSystemInfo> getFileSystems(boolean deferredUsageInfo) {
         List<String> mountPoints = new ArrayList<String>();
 
         try {
@@ -322,10 +322,18 @@ public class NativeSystemInfo implements SystemInfo {
 
         List<FileSystemInfo> infos = new ArrayList<FileSystemInfo>();
         for (String mountPoint : mountPoints) {
-            infos.add(new FileSystemInfo(mountPoint));
+            infos.add(new FileSystemInfo(mountPoint, deferredUsageInfo));
         }
 
         return infos;
+    }
+
+    public List<FileSystemInfo> getFileSystems() {
+        return getFileSystems(false);
+    }
+
+    public List<FileSystemInfo> getFileSystemsDeferredUsageInfo() {
+        return getFileSystems(true);
     }
 
     public FileSystemInfo getFileSystem(String path) {

--- a/modules/core/native-system/src/main/java/org/rhq/core/system/SystemInfo.java
+++ b/modules/core/native-system/src/main/java/org/rhq/core/system/SystemInfo.java
@@ -203,6 +203,16 @@ public interface SystemInfo {
     List<FileSystemInfo> getFileSystems();
 
     /**
+     * Returns information on all mounted file systems,
+     *
+     * The usage information will be obtained when the method {@link FileSystemInfo#getFileSystemUsage()} is called.
+     *
+     * @return list of all file systems on the platform
+     */
+
+    List<FileSystemInfo> getFileSystemsDeferredUsageInfo();
+
+    /**
      * Returns information on the mounted file system that hosts the given file or directory.
      *
      * @param  path the file or directory whose mounted file system should be returned

--- a/modules/plugins/platform/src/main/java/org/rhq/plugins/platform/FileSystemDiscoveryComponent.java
+++ b/modules/plugins/platform/src/main/java/org/rhq/plugins/platform/FileSystemDiscoveryComponent.java
@@ -62,7 +62,7 @@ public class FileSystemDiscoveryComponent implements ResourceDiscoveryComponent<
             return results;
         }
 
-        for (FileSystemInfo fsInfo : sysInfo.getFileSystems()) {
+        for (FileSystemInfo fsInfo : sysInfo.getFileSystemsDeferredUsageInfo()) {
             FileSystem fs = fsInfo.getFileSystem();
             int fsType = fs.getType();
             // We only support local, network (nfs), lofs, or tmpfs filesystems - skip any other types.


### PR DESCRIPTION
…l other child resources take 5 minutes to discover if NFS mount exists to host that is blocking RPC port

Sigar tries to do an RPC ping when you request information about the NFS mounted file system, but the RPC ping doesn't have a time out, and as far as I know there is no way to set it.

Because of that I did this:

I don't try to fetch the file usage information on the discovery thread anymore, instead it will be deferred until  the metrics or availability information are needed.

This prevents time out expires on the discovery process, in the availability thread is ok to hanging it because is per resource and it has a time out (I think 1 minute), when the timeout expires the thread is interrupted and the resource is marked as unavailable (in this case the nfs file system), for that reason is ok to request the file system use information on that thread.



