### PR TITLE
Bug 1212495 - Solaris10-Error in server log after Generate JDR Report…

### DIFF
--- a/modules/enterprise/server/plugins/jdr-support/src/main/java/org/rhq/enterprise/server/plugins/jdr/JdrServerPluginComponent.java
+++ b/modules/enterprise/server/plugins/jdr-support/src/main/java/org/rhq/enterprise/server/plugins/jdr/JdrServerPluginComponent.java
@@ -86,17 +86,13 @@ public class JdrServerPluginComponent implements ServerPluginComponent {
             PrintWriter pw = new PrintWriter(file);
             pw.println(accessToken);
             pw.close();
+            // Clear permissions
+            file.setReadable(false, false);
+            file.setWritable(false, false);
+            file.setExecutable(false, false);
+            // Only set permissions to user
             file.setWritable(true, true);
             file.setReadable(true, true);
-            file.setExecutable(false, false);
-            boolean isWindows = (File.separatorChar == '\\');
-            if (!isWindows) {
-                try {
-                    Runtime.getRuntime().exec("chmod 600 "+file.getAbsolutePath());
-                } catch (IOException e) {
-                    log.error("Unable to set file permissions", e);
-                }
-            }
         } catch (FileNotFoundException fnfe) {
             log.error("Failed to write acces token, jboss.server.data.dir="+file.getParent()+" does not exist or not writable");
         }


### PR DESCRIPTION
… operation

Removes the fork to avoid low swap memory conditions.

That seems to be a problem with not enough *swap* space [1] [2]. 
A solution is to remove that chmod call, while still having the permissions set to 600.

[1] https://docs.oracle.com/cd/E19455-01/806-1075/msgs-1831/index.html
[2] https://community.oracle.com/thread/2458428?tstart=0