### PR TITLE
Bug 1213812 - After upgrade from JBoss ON 3.2 to 3.3, some rhq column…

### DIFF
--- a/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/InstallerServiceImpl.java
+++ b/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/InstallerServiceImpl.java
@@ -711,6 +711,8 @@ public class InstallerServiceImpl implements InstallerService {
             ExistingSchemaOption.KEEP);
         ServerInstallUtil.persistStorageNodesIfNecessary(serverProperties, clearTextDbPassword,
             parseNodeInformation(serverProperties, storageNodeAddresses));
+
+        ServerInstallUtil.removeObsoleteStorageColumnFamilies(serverProperties, clearTextDbPassword);
     }
 
     private Set<String> prepareStorageSchema(HashMap<String, String> serverProperties, String clearTextDbPassword,


### PR DESCRIPTION
… families are unavailable and compaction operations fail

I marked the obsolete column families `one_hour_metrics`, `six_hour_metrics`, `twenty_four_hour metrics` and `metrics_index` as uninventoried.

There is no need to create a new operation, this is because when the discovery process adds the new column families the operation  automatically applies to the new column families resources discovered under the group.

I tested it and it seems to work well, but I'm not sure about that is the right place to put this code, I run this process as part of storage schema upgrade

` ./rhqctl upgrade --storage-schema `


