### PR TITLE
[BZ 1213812] Add clear columnfamilies option to rhqctl upgrade

### DIFF
--- a/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/InstallerService.java
+++ b/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/InstallerService.java
@@ -148,6 +148,8 @@ public interface InstallerService {
      */
     void updateStorageSchema(HashMap<String, String> serverProperties) throws Exception;
 
+    void clearColumnFamilies(HashMap<String, String> serverProperties) throws Exception;
+
     /**
      * Returns a list of all registered servers in the database.
      *

--- a/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/InstallerServiceImpl.java
+++ b/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/InstallerServiceImpl.java
@@ -711,7 +711,15 @@ public class InstallerServiceImpl implements InstallerService {
             ExistingSchemaOption.KEEP);
         ServerInstallUtil.persistStorageNodesIfNecessary(serverProperties, clearTextDbPassword,
             parseNodeInformation(serverProperties, storageNodeAddresses));
+        clearColumnFamilies(serverProperties);
+    }
 
+    @Override
+    public void clearColumnFamilies(HashMap<String, String> serverProperties) throws Exception {
+        String clearTextDbPassword;
+        String obfuscatedDbPassword;
+        obfuscatedDbPassword = serverProperties.get(ServerProperties.PROP_DATABASE_PASSWORD);
+        clearTextDbPassword = PicketBoxObfuscator.decode(obfuscatedDbPassword);
         ServerInstallUtil.removeObsoleteStorageColumnFamilies(serverProperties, clearTextDbPassword);
     }
 

--- a/modules/enterprise/server/server-control/src/main/java/org/rhq/server/control/command/AbstractInstall.java
+++ b/modules/enterprise/server/server-control/src/main/java/org/rhq/server/control/command/AbstractInstall.java
@@ -481,7 +481,7 @@ public abstract class AbstractInstall extends ControlCommand {
 
     protected enum ServerInstallerAction {
         INSTALL("Installing"), UPGRADE("Upgrading"), UPDATESTORAGESCHEMA("Updating RHQ Storage Cluster schema"), LISTVERSIONS(
-            "Topology Versions");
+            "Topology Versions"), CLEARCOLUMNFAMILIES("Clear inventory of obsolete column families");
 
         public String display;
 
@@ -522,6 +522,13 @@ public abstract class AbstractInstall extends ControlCommand {
             log.info("The RHQ Server installer is running");
             break;
         }
+            case CLEARCOLUMNFAMILIES: {
+                log.info(serverInstallerAction.display);
+                org.apache.commons.exec.CommandLine commandLine = getCommandLine("rhq-installer", "--clearcolumnfamilies");
+                integerFuture = ExecutorAssist.executeAsync(getBinDir(), commandLine, null);
+                log.info("The RHQ Server column family cleaning is running");
+                break;
+            }
         case UPDATESTORAGESCHEMA: {
             log.info(serverInstallerAction.display);
 


### PR DESCRIPTION
If no storage-schema update is needed, use this one to run only the removeObsoleteColumnFamilies..