### PR TITLE
Set default values to empty string or its initial values 

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseProcessDiscovery.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseProcessDiscovery.java
@@ -247,8 +247,9 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
 
         ProcessInfo agentProcess = discoveryContext.getSystemInformation().getThisProcess();
         setStartScriptPluginConfigProps(process, commandLine, pluginConfig, agentProcess);
-        setUserAndPasswordPluginConfigProps(serverPluginConfig, hostConfig);
-
+        // Fixed username and password due BZ:1379834
+        serverPluginConfig.setUser(RHQADMIN);
+        serverPluginConfig.setPassword(RHQADMIN);
         String key = createKeyForLocalResource(serverPluginConfig);
         HostPort hostPort = hostConfig.getDomainControllerHostPort(commandLine);
         String name = buildDefaultResourceName(hostPort, managementHostPort, productType, hostConfig.getHostName());

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/SchemeRegistryBuilder.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/SchemeRegistryBuilder.java
@@ -59,7 +59,8 @@ class SchemeRegistryBuilder {
             SSLSocketFactory sslSocketFactory;
             try {
                 KeyStore truststore = null;
-                if (asConnectionParams.getTruststore() != null) {
+                if (asConnectionParams.getTruststore() != null && !asConnectionParams.getTruststore().trim().isEmpty
+                        ()) {
                     truststore = loadKeystore( //
                         asConnectionParams.getTruststoreType(), //
                         asConnectionParams.getTruststore(), //
@@ -69,7 +70,7 @@ class SchemeRegistryBuilder {
                 KeyStore keystore = null;
                 String keyPassword = null;
                 if (asConnectionParams.isClientcertAuthentication()) {
-                    if (asConnectionParams.getKeystore() == null) {
+                    if (asConnectionParams.getKeystore() == null || asConnectionParams.getKeystore().trim().isEmpty()) {
                         keystore = loadKeystore( //
                             System.getProperty("javax.net.ssl.keyStoreType", KeyStore.getDefaultType()), //
                             System.getProperty("javax.net.ssl.keyStore"), //
@@ -82,6 +83,7 @@ class SchemeRegistryBuilder {
                             asConnectionParams.getKeystorePassword() //
                         );
                         keyPassword = asConnectionParams.getKeyPassword();
+                        keyPassword = (keyPassword == null || keyPassword.trim().isEmpty()) ? null : keyPassword;
                     }
                 }
                 sslSocketFactory = new SSLSocketFactory(null, keystore, keyPassword, truststore, null,

--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/util/SecurityUtil.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/util/SecurityUtil.java
@@ -42,7 +42,8 @@ public class SecurityUtil {
      */
     public static KeyStore loadKeystore(String keystoreType, String keystore, String keystorePassword) throws Exception {
         KeyStore ks = KeyStore.getInstance(keystoreType);
-        char[] password = keystorePassword == null ? null : keystorePassword.toCharArray();
+        char[] password = (keystorePassword == null || keystorePassword.trim().isEmpty())? null : keystorePassword
+                .toCharArray();
         FileInputStream fileInputStream = null;
         try {
             fileInputStream = new FileInputStream(keystore);

--- a/modules/plugins/jboss-as-7/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/jboss-as-7/src/main/resources/META-INF/rhq-plugin.xml
@@ -114,7 +114,7 @@
 
     <!ENTITY managementInterfaceSecureConnectionSettings '
     <c:group name="secureConnectionSettings">
-      <c:simple-property name="trustStrategy" default="standard">
+      <c:simple-property name="trustStrategy" default="standard" defaultValue="standard">
         <c:description>
           Defines the trust strategy to use when reading the server certificate:
           &lt;ul&gt;
@@ -129,7 +129,7 @@
           <c:option value="trustAny" name="Trust Any"/>
         </c:property-options>
       </c:simple-property>
-      <c:simple-property name="hostnameVerification" default="strict">
+      <c:simple-property name="hostnameVerification" default="strict" defaultValue="strict">
         <c:description>
           Defines the hostname verification logic:
           &lt;ul&gt;
@@ -147,12 +147,12 @@
           <c:option value="skip" name="Skip"/>
         </c:property-options>
       </c:simple-property>
-      <c:simple-property name="truststore" required="false">
+      <c:simple-property name="truststore" required="false" defaultValue=" " default=" ">
         <c:description>
           Path to a truststore file. If undefined, the JVM default truststore is used.
         </c:description>
       </c:simple-property>
-      <c:simple-property name="truststoreType" required="false" default="jks">
+      <c:simple-property name="truststoreType" required="false" default="jks" defaultValue="jks">
         <c:description>
           Truststore file format (required when the &lt;em&gt;Truststore&lt;/em&gt; property is set).
           All certified JVMs support &lt;em&gt;jks&lt;/em&gt; (Java KeyStore) or &lt;em&gt;pkcs12&lt;/em&gt; formats.
@@ -162,18 +162,18 @@
           <c:option value="pkcs12"/>
         </c:property-options>
       </c:simple-property>
-      <c:simple-property name="truststorePassword" required="false" type="password">
+      <c:simple-property name="truststorePassword" required="false" type="password" defaultValue=" " default=" ">
         <c:description>
           Password protecting the truststore file.
         </c:description>
       </c:simple-property>
-      <c:simple-property name="clientcertAuthentication" default="false" type="boolean" displayName="Client Certificate Authentication"/>
-      <c:simple-property name="keystore" required="false">
+      <c:simple-property name="clientcertAuthentication" default="false" defaultValue="false" type="boolean" displayName="Client Certificate Authentication"/>
+      <c:simple-property name="keystore" required="false" defaultValue=" " default=" ">
         <c:description>
           Path to a keystore file. Required when &lt;em&gt;Client Certificate Authentication&lt;/em&gt; is on.
         </c:description>
       </c:simple-property>
-      <c:simple-property name="keystoreType" required="false" default="jks">
+      <c:simple-property name="keystoreType" required="false" default="jks" defaultValue="jks" >
         <c:description>
           Keystore file format (required when the &lt;em&gt;Keystore&lt;/em&gt; property is set).
           All certified JVMs support &lt;em&gt;jks&lt;/em&gt; (Java KeyStore) or &lt;em&gt;pkcs12&lt;/em&gt; formats.
@@ -183,12 +183,12 @@
           <c:option value="pkcs12"/>
         </c:property-options>
       </c:simple-property>
-      <c:simple-property name="keystorePassword" required="false" type="password">
+      <c:simple-property name="keystorePassword" required="false" type="password" defaultValue=" " default=" ">
         <c:description>
           Password protecting the keystore file.
         </c:description>
       </c:simple-property>
-      <c:simple-property name="keyPassword" required="false" type="password">
+      <c:simple-property name="keyPassword" required="false" type="password" defaultValue=" " default=" ">
         <c:description>
           Password protecting the secret key in the keystore file.
         </c:description>
@@ -1108,12 +1108,18 @@
           description="Domain controller (delegate) for this host">
 
     <plugin-configuration>
-      <c:simple-property name="hostname" default="localhost" required="true" description="Host name of the domain API"/>
-      <c:simple-property name="port" default="9990" type="integer" required="true" description="Port of the domain API"/>
-      <c:simple-property name="secure" default="false" type="boolean" description="Encrypted transport indicator"/>
-      <c:simple-property name="user" type="string" description="Management user for a secured Host controller" required="false"/>
-      <c:simple-property name="password" type="password" description="Password for the management user" required="false"/>
-      <c:simple-property name="managementConnectionTimeout" type="long" description="Maximum time in milliseconds to keep alive an idle management connection. Zero and negative values will disable connection persistence. Defaults to 5000 ms." required="false" default="5000"/>
+      <c:simple-property name="hostname" default="localhost" defaultValue="localhost" required="true"
+                         description="Host name of the domain API"/>
+      <c:simple-property name="port" default="9990" defaultValue="9990" type="integer" required="true"
+                         description="Port of the domain API"/>
+      <c:simple-property name="secure" defaultValue="false" default="false" type="boolean"
+                         description="Encrypted transport indicator"/>
+      <c:simple-property name="user" defaultValue=" " default=" " type="string"
+                         description="Management user for a secured Host controller" required="false"/>
+      <c:simple-property name="password" defaultValue=" " default=" " type="password"
+                         description="Password for the management user" required="false"/>
+      <c:simple-property name="managementConnectionTimeout" type="long"
+                         description="Maximum time in milliseconds to keep alive an idle management connection. Zero and negative values will disable connection persistence. Defaults to 5000 ms." required="false" default="5000" defaultValue="5000"/>
       <c:simple-property name="homeDir" type="file" description="Root directory of the server installation" displayName="Home Directory" readOnly="true" required="false"/>
       <c:simple-property name="baseDir" type="file" description="Base directory for server content" displayName="Base Directory" readOnly="true" required="false"/>
       <c:simple-property name="configDir" type="file" description="Base configuration directory" displayName="Configuration Directory" readOnly="true" required="false"/>
@@ -1493,12 +1499,16 @@
           supportsManualAdd="true">
 
     <plugin-configuration>
-      <c:simple-property name="hostname" default="localhost" required="true"/>
-      <c:simple-property name="port" default="9990" type="integer" required="true"/>
-      <c:simple-property name="secure" default="false" type="boolean" description="Encrypted transport indicator"/>
-      <c:simple-property name="user" type="string" description="Management user for a secured AS" required="false"/>
-      <c:simple-property name="password" type="password" description="Password for the management user" required="false"/>
-      <c:simple-property name="managementConnectionTimeout" type="long" description="Maximum time in milliseconds to keep alive an idle management connection. Zero and negative values will disable connection persistence. Defaults to 5000 ms." required="false" default="5000"/>
+      <c:simple-property name="hostname" default="localhost" defaultValue="localhost" required="true"/>
+      <c:simple-property name="port" defaultValue="9990" default="9990" type="integer" required="true"/>
+      <c:simple-property name="secure" defaultValue="false" default="false" type="boolean"
+                         description="Encrypted transport indicator"/>
+      <c:simple-property name="user" type="string" defaultValue="rhqadmin"
+                         description="Management user for a secured AS" required="false"/>
+      <c:simple-property name="password" type="password" defaultValue="rhqadmin" default="rhqadmin"
+                         description="Password for the management user" required="false"/>
+      <c:simple-property name="managementConnectionTimeout" defaultValue="5000" type="long"
+                         description="Maximum time in milliseconds to keep alive an idle management connection. Zero and negative values will disable connection persistence. Defaults to 5000 ms." required="false" default="5000"/>
       <c:simple-property name="homeDir" type="file" description="Root directory of the server installation" displayName="Home Directory" readOnly="true" required="false"/>
       <c:simple-property name="baseDir" type="file" description="Base directory for server content" displayName="Base Directory" readOnly="true" required="false"/>
       <c:simple-property name="configDir" type="file" description="Base configuration directory" displayName="Configuration Directory" readOnly="true" required="false"/>
@@ -1565,8 +1575,8 @@
             for these changes to take effect.
           </c:description>
         </c:simple-property>
-        <c:simple-property name="nativeHost" default="127.0.0.1" required="true" description="Native management API host"/>
-        <c:simple-property name="nativePort" type="integer" required="true" default="9999" description="Native management API port" />
+        <c:simple-property name="nativeHost" defaultValue="127.0.0.1" default="127.0.0.1" required="true" description="Native management API host"/>
+        <c:simple-property name="nativePort" type="integer" required="true" default="9999" defaultValue="9999" description="Native management API port" />
         <c:simple-property name="nativeLocalAuth" required="false" displayName="Native Local Authentication" type="boolean">
             <c:description>
             Specifies if the local authentication should be used to interact with the EAP CLI 


### PR DESCRIPTION
Also, removed user/password discovery

See BZ:1379834

This still needs more testing to merge.. if this works, It seems like we need to do the same thing with EAP7 plugin.

Edit: Set defaultValue to one space because oracle database interprets empty string as a  null 

(http://stackoverflow.com/questions/13278773/null-vs-empty-string-in-oracle
http://stackoverflow.com/questions/5510509/oracle-treating-empty-string-as-null-problem-for-a-java-jpa-programmer
)
