### PR TITLE
Bug 1382649 -Attempt to add notification for the second alert..

### DIFF
--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/alert/definitions/NotificationsAlertDefinitionForm.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/alert/definitions/NotificationsAlertDefinitionForm.java
@@ -216,11 +216,18 @@ public class NotificationsAlertDefinitionForm extends EnhancedVLayout implements
             return null;
         }
 
+        AlertNotification[] prepareNotificationsForPreview(){
+            for(AlertNotification n: notifications){
+                n.getAlertDefinition().getResource().getAlertDefinitions().clear();
+            }
+            return notifications.toArray(new AlertNotification[notifications.size()]);
+        }
+
         @Override
         protected void executeFetch(final DSRequest request, final DSResponse response, final Criteria unused) {
             final Record[] records = buildRecords(notifications); // partially builds the records, but we need to do another remote call to get the config preview
 
-            AlertNotification[] notifs = notifications.toArray(new AlertNotification[notifications.size()]);
+            AlertNotification[] notifs = prepareNotificationsForPreview();
             GWTServiceLookup.getAlertDefinitionService().getAlertNotificationConfigurationPreview(notifs,
                 new AsyncCallback<String[]>() {
                     @Override


### PR DESCRIPTION
Bug 1382649  Attempt to add notification for the second alert definition in JBoss ON UI throws message "Failed to get notification configuration preview".

  
Removed recursive AlertDefinition seems to solve the problem of deserialization for GWT.

