### PR TITLE
Bug 1364474 - PARTITION_EVENT_PURGE and RESOURCE_CONFIG_HISTORY_PURGE properties remain in the database after 3.3.6

### DIFF
--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/system/SystemManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/system/SystemManagerBean.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.DateFormat;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -910,9 +911,13 @@ public class SystemManagerBean implements SystemManagerLocal, SystemManagerRemot
     private void fillCache(Collection<SystemConfiguration> configs) {
         SystemSettings settings = new SystemSettings();
 
+        String[] obsoleteValues = {"PARTITION_EVENT_PURGE", "RESOURCE_CONFIG_HISTORY_PURGE"};
+
         for (SystemConfiguration config : configs) {
-            SystemSetting prop = SystemSetting.getByInternalName(config.getPropertyKey());
-            if (prop == null) {
+            String configKey = config.getPropertyKey();
+
+            SystemSetting prop = SystemSetting.getByInternalName(configKey);
+            if (prop == null && !Arrays.asList(obsoleteValues).contains(configKey) ) {
                 LOG.warn("The database contains unknown system configuration setting [" + config.getPropertyKey()
                     + "].");
                 continue;


### PR DESCRIPTION
Silence warning for system properties PARTITION_EVENT_PURGE and RESOURCE_CONFIG_HISTORY_PURGE…