### PR TITLE
Bug 1368107 - Update the minimumPagesize to match the new minimum.

### DIFF
--- a/modules/enterprise/gui/portal-war/src/main/java/org/rhq/enterprise/gui/common/framework/PagedDataTableUIBean.java
+++ b/modules/enterprise/gui/portal-war/src/main/java/org/rhq/enterprise/gui/common/framework/PagedDataTableUIBean.java
@@ -22,6 +22,7 @@ import javax.faces.event.ActionEvent;
 import javax.faces.model.DataModel;
 import javax.faces.model.SelectItem;
 
+import org.rhq.enterprise.gui.common.paging.PageControlSettingsUIBean;
 import org.richfaces.component.UIDataTable;
 import org.richfaces.component.UIDatascroller;
 
@@ -35,8 +36,7 @@ public abstract class PagedDataTableUIBean extends EnterpriseFacesContextUIBean 
     protected DataModel dataModel;
     private UIDataTable dataTable;
     private UIDatascroller datascroller;
-    private SelectItem[] pageSizes = new SelectItem[] { new SelectItem("15", "15"), new SelectItem("30", "30"),
-        new SelectItem("45", "45") };
+    private PageControlSettingsUIBean pageControlSettings = new PageControlSettingsUIBean();
 
     public PageControl getPageControl(WebUser user, PageControlView view) {
         if (pageControl == null) {
@@ -109,11 +109,11 @@ public abstract class PagedDataTableUIBean extends EnterpriseFacesContextUIBean 
     }
 
     public SelectItem[] getPageSizes() {
-        return pageSizes;
+        return pageControlSettings.getPageSizes();
     }
 
     public int getMinimumPageSize() {
-        return 15;
+        return pageControlSettings.getMinimumPageSize();
     }
 
     public void clearDataModel(ActionEvent event) {

--- a/modules/enterprise/gui/portal-war/src/main/java/org/rhq/enterprise/gui/common/paging/PageControlSettingsUIBean.java
+++ b/modules/enterprise/gui/portal-war/src/main/java/org/rhq/enterprise/gui/common/paging/PageControlSettingsUIBean.java
@@ -25,6 +25,7 @@ import javax.faces.model.SelectItem;
  */
 public class PageControlSettingsUIBean {
     private SelectItem[] pageSizes;
+    private int minimumPageSize = 15;
     private static String MAX_ITEMS_PER_PAGE = "rhq.server.gui.max-items-per-page";
 
     public PageControlSettingsUIBean() {
@@ -33,7 +34,8 @@ public class PageControlSettingsUIBean {
             int maxItemsPerPageInt;
             if (maxItemsPerPage != null && (maxItemsPerPageInt = Integer.parseInt(maxItemsPerPage)) >= 45) {
                 // Scale default page sizes
-                String tier0 = String.valueOf(Math.max(15, (int) (maxItemsPerPageInt * 0.25)));
+                minimumPageSize = Math.max(15, (int) (maxItemsPerPageInt * 0.25));
+                String tier0 = String.valueOf(minimumPageSize);
                 String tier1 = String.valueOf(Math.max(30, (int) (maxItemsPerPageInt * 0.50)));
                 String tier2 = String.valueOf(Math.max(45, (int) (maxItemsPerPageInt * 0.75)));
                 pageSizes = new SelectItem[] { new SelectItem(tier0, tier0), new SelectItem(tier1, tier1),
@@ -54,6 +56,6 @@ public class PageControlSettingsUIBean {
     }
 
     public int getMinimumPageSize() {
-        return 15;
+        return minimumPageSize;
     }
 }


### PR DESCRIPTION
 Increases the amount on PagedDataTable to match PageControlSettingsUIBean.

This is a follow up on https://github.com/rhq-project/rhq/pull/285.
When modifying 15/30/45 to scale with the max I forgot to also scale the minimum value.
Also noticed that there was another minimum page that was being used for listing the rows. 