### PR TITLE
Bug 1427571 - Solve Unusable group metric graphs.

### DIFF
--- a/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/inventory/groups/detail/monitoring/table/CompositeGroupD3MultiLineGraph.java
+++ b/modules/enterprise/gui/coregui/src/main/java/org/rhq/coregui/client/inventory/groups/detail/monitoring/table/CompositeGroupD3MultiLineGraph.java
@@ -291,7 +291,11 @@ public class CompositeGroupD3MultiLineGraph extends CompositeGroupD3GraphListVie
                         .attr("stroke", function(d,i){ return colorScale(i);})
                         .attr("stroke-width", "2")
                         .attr("stroke-opacity", ".9")
-                        .attr("d", function(d) { return graphLine(d.value);});
+                        .attr("d", function(d) { return graphLine(
+                            d.value.filter(function(d) {
+                                return ('nodata' in d)? !d.nodata : true;
+                            })
+                        );});
 
                 for (var i=0;i<chartContext.data.length;++i) {
                     svg.selectAll("dot")
@@ -301,11 +305,11 @@ public class CompositeGroupD3MultiLineGraph extends CompositeGroupD3GraphListVie
                         .filter(function(d) {
                             return ('nodata' in d)? !d.nodata : true;
                         })
-                        .attr("stroke", "black")
-                        .attr("stroke-width", "2")
+                        .attr("stroke", function(){ return colorScale(i);})
+                        .attr("stroke-width", "1")
                         .attr("stroke-opacity", ".9")
-                        .attr("fill", "none")
-                        .attr("r", 3.5)
+                        .attr("fill", function(){ return colorScale(i);})
+                        .attr("r", 2)
                         .attr("cx", function(d) {
                             return timeScale(d.x);
                         })


### PR DESCRIPTION
Removes the black circle and non-existent data, adds a dot to mark existent data.

Before:
![graph01_before](https://cloud.githubusercontent.com/assets/3845764/23573813/69c769ca-003e-11e7-9fb1-934d93f5eab3.png)

After:
![graph01_after](https://cloud.githubusercontent.com/assets/3845764/23573812/69c1de88-003e-11e7-9e7c-ac1a2fe16263.png)

Before:
![graph02_before](https://cloud.githubusercontent.com/assets/3845764/23573814/69caa75c-003e-11e7-9d3f-25da52a49436.png)

After:
![graph02_after](https://cloud.githubusercontent.com/assets/3845764/23573811/69bc1e62-003e-11e7-8f24-9aeca7838f53.png)
