### PR TITLE
Force  updateBackingContent to discover the new package in sync manner.

### DIFF
--- a/modules/enterprise/binding/src/main/java/org/rhq/bindings/client/ResourceClientProxy.java
+++ b/modules/enterprise/binding/src/main/java/org/rhq/bindings/client/ResourceClientProxy.java
@@ -46,8 +46,10 @@ import org.rhq.core.domain.configuration.PluginConfigurationUpdate;
 import org.rhq.core.domain.configuration.ResourceConfigurationUpdate;
 import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
 import org.rhq.core.domain.content.InstalledPackage;
+import org.rhq.core.domain.content.PackageDetailsKey;
 import org.rhq.core.domain.content.PackageType;
 import org.rhq.core.domain.content.PackageVersion;
+import org.rhq.core.domain.content.transfer.ResourcePackageDetails;
 import org.rhq.core.domain.criteria.MeasurementDefinitionCriteria;
 import org.rhq.core.domain.criteria.MeasurementScheduleCriteria;
 import org.rhq.core.domain.criteria.OperationDefinitionCriteria;
@@ -616,6 +618,13 @@ public class ResourceClientProxy {
 
             contentManager.deployPackagesWithNote(remoteClient.getSubject(), new int[] { resourceClientProxy.getId() },
                 new int[] { pv.getId() }, "CLI deployment request");
+            PackageDetailsKey keys = new PackageDetailsKey(
+                    oldPackage.getPackageVersion().getGeneralPackage().getName(),
+                    packageVersion,
+                    oldPackage.getPackageVersion().getGeneralPackage().getPackageType().getName(),
+                    oldPackage.getPackageVersion().getArchitecture().getName());
+            ResourcePackageDetails details = new ResourcePackageDetails(keys);
+            contentManager.mergePackage(remoteClient.getSubject(), resourceClientProxy.getId(), details);
         }
 
         public void retrieveBackingContent(String fileName) throws IOException {

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/content/ContentManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/content/ContentManagerBean.java
@@ -177,6 +177,25 @@ public class ContentManagerBean implements ContentManagerLocal, ContentManagerRe
     private SubjectManagerLocal subjectManager;
 
     // ContentManagerLocal Implementation  --------------------------------------------
+    @Override
+    @TransactionAttribute(TransactionAttributeType.NEVER)
+    public void mergePackage(Subject subject, int resourceId, ResourcePackageDetails details) {
+
+        // Check permissions first
+        if (!authorizationManager.hasResourcePermission(subject, Permission.MANAGE_CONTENT, resourceId)) {
+            throw new PermissionException("User [" + subject.getName()
+                    + "] does not have permission to merge package details from resource ID [" + resourceId + "]");
+        }
+
+
+        ContentDiscoveryReport report = new ContentDiscoveryReport();
+        Set<ResourcePackageDetails> installedPackagesSet = new HashSet<ResourcePackageDetails>();
+        installedPackagesSet.add(details);
+
+        report.addAllDeployedPackages(installedPackagesSet);
+        report.setResourceId(resourceId);
+        contentManager.mergeDiscoveredPackages(report);
+    }
 
     @Override
     @TransactionAttribute(TransactionAttributeType.NEVER)

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/content/ContentManagerRemote.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/content/ContentManagerRemote.java
@@ -30,6 +30,7 @@ import org.rhq.core.domain.content.PackageType;
 import org.rhq.core.domain.content.PackageVersion;
 import org.rhq.core.domain.content.composite.PackageAndLatestVersionComposite;
 import org.rhq.core.domain.content.composite.PackageTypeAndVersionFormatComposite;
+import org.rhq.core.domain.content.transfer.ResourcePackageDetails;
 import org.rhq.core.domain.criteria.InstalledPackageCriteria;
 import org.rhq.core.domain.criteria.PackageCriteria;
 import org.rhq.core.domain.criteria.PackageVersionCriteria;
@@ -291,4 +292,7 @@ public interface ContentManagerRemote {
      */
     PackageVersion createPackageVersionWithDisplayVersion(Subject subject, String packageName, int packageTypeId,
         String version, String displayVersion, Integer architectureId, String temporaryContentHandle);
+
+    //To force to discovery certain package
+    void mergePackage(Subject subject, int resourceId, ResourcePackageDetails details);
 }


### PR DESCRIPTION
Not tested yet, but this should fix BZ-1420712 and BZ-1420717

Don't merge yet.