### PR TITLE
Bug 1419531 - Use network device description for display name on windows

### DIFF
--- a/modules/core/native-system/src/main/java/org/rhq/core/system/NativeSystemInfo.java
+++ b/modules/core/native-system/src/main/java/org/rhq/core/system/NativeSystemInfo.java
@@ -142,12 +142,19 @@ public class NativeSystemInfo implements SystemInfo {
             String[] interfaceNames = sigar.getNetInterfaceList();
 
             if (interfaceNames != null) {
+                NetworkAdapterInfo.DisplayName displayName = NetworkAdapterInfo.DisplayName.FROM_NAME;
+                // If Sigar can't get the adapter name it just starts naming the network adapters as eth0, eth1, etc.
+                // This can be confusing on Windows, so we switch to their description
+                // All references should be the same, as we are are only changing the displayName
+                if (this.getOperatingSystemType() == OperatingSystemType.WINDOWS) {
+                    displayName = NetworkAdapterInfo.DisplayName.FROM_DESCRIPTION;
+                }
                 for (String interfaceName : interfaceNames) {
                     if (interfaceName.indexOf(':') != -1) {
                         continue; //filter out virtual IPs
                     }
 
-                    adapters.add(new NetworkAdapterInfo(sigar.getNetInterfaceConfig(interfaceName)));
+                    adapters.add(new NetworkAdapterInfo(sigar.getNetInterfaceConfig(interfaceName), displayName));
                 }
             }
         } catch (Exception e) {

--- a/modules/core/native-system/src/main/java/org/rhq/core/system/NetworkAdapterInfo.java
+++ b/modules/core/native-system/src/main/java/org/rhq/core/system/NetworkAdapterInfo.java
@@ -56,6 +56,11 @@ public class NetworkAdapterInfo {
         UP, DOWN, TESTING, UNKNOWN, DORMANT, NOTPRESENT, LOWERLAYERDOWN
     }
 
+    public enum DisplayName {
+        FROM_NAME,
+        FROM_DESCRIPTION
+    }
+
     public NetworkAdapterInfo(String name, String displayName, String description, String macAddress, String type,
         String operationalStatus, Boolean dhcpEnabled, List<InetAddress> dnsServers,
         List<InetAddress> unicastAddresses, List<InetAddress> multicastAddresses) {
@@ -72,6 +77,10 @@ public class NetworkAdapterInfo {
     }
 
     public NetworkAdapterInfo(NetInterfaceConfig a) {
+        this(a, DisplayName.FROM_NAME);
+    }
+
+    public NetworkAdapterInfo(NetInterfaceConfig a, DisplayName displayName) {
         long flags = a.getFlags();
         NetworkAdapterInfo.OperationState state = NetworkAdapterInfo.OperationState.UP;
         if ((flags & NetFlags.IFF_UP) <= 0) {
@@ -79,7 +88,15 @@ public class NetworkAdapterInfo {
         }
 
         this.name = a.getName();
-        this.displayName = a.getName();
+        switch(displayName) {
+            case FROM_DESCRIPTION:
+                this.displayName = a.getDescription();
+                break;
+            case FROM_NAME:
+            default:
+                this.displayName = a.getName();
+                break;
+        }
         this.description = a.getDescription();
         this.macAddress = a.getHwaddr();
         this.type = a.getType();


### PR DESCRIPTION
This will update displayName of network adapters, using the description instead of the autogenerated "ethX" which might confuse users.

These interfaces don't show when running `ipconfig /all`, but they do appear in the device manager.

![screenshot from 2017-08-29 18-42-27](https://user-images.githubusercontent.com/3845764/29849030-e18e3848-8ce9-11e7-98e0-1d26a43dc05f.png)
