### PR TITLE
Bug 1455091 - Attemp to fix non valid values when starting the plugin

### DIFF
--- a/modules/enterprise/server/plugins/alert-snmp/src/main/java/org/rhq/enterprise/server/plugins/alertSnmp/SNMPComponent.java
+++ b/modules/enterprise/server/plugins/alert-snmp/src/main/java/org/rhq/enterprise/server/plugins/alertSnmp/SNMPComponent.java
@@ -1,0 +1,63 @@
+package org.rhq.enterprise.server.plugins.alertSnmp;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.core.domain.plugin.ServerPlugin;
+import org.rhq.enterprise.server.plugin.ServerPluginManagerLocal;
+import org.rhq.enterprise.server.plugin.pc.ServerPluginComponent;
+import org.rhq.enterprise.server.plugin.pc.ServerPluginContext;
+import org.rhq.enterprise.server.util.LookupUtil;
+
+public class SNMPComponent implements ServerPluginComponent {
+
+    private static final Log LOG = LogFactory.getLog(SNMPComponent.class);
+
+    public static final String PROP_TRANSPORT = "transport";
+
+    public static final String TRANSPORT_UDP = "UDP";
+    public static final String TRANSPORT_TCP = "TCP";
+    public static final String DEFAULT_TRANSPORT = TRANSPORT_UDP;
+
+
+    @Override
+    public void initialize(ServerPluginContext context) throws Exception {
+        try {
+            Configuration configuration = context.getPluginConfiguration();
+            if (configuration != null) {
+                final List<String> VALID_TRANSPORTS = Arrays.asList(TRANSPORT_UDP, TRANSPORT_TCP);
+
+                String transportValue = configuration.getSimpleValue(PROP_TRANSPORT, null);
+                if (transportValue == null || !VALID_TRANSPORTS.contains(transportValue)) {
+                    ServerPluginManagerLocal spm = LookupUtil.getServerPluginManager();
+                    ServerPlugin serverPlugin  = spm.getServerPlugin(context.getPluginEnvironment().getPluginKey());
+                    serverPlugin.getPluginConfiguration().setSimpleValue(PROP_TRANSPORT, DEFAULT_TRANSPORT);
+                    LookupUtil.getServerPluginManager().updateServerPluginExceptContent(
+                            LookupUtil.getSubjectManager().getOverlord(),
+                            serverPlugin
+                    );
+                }
+            }
+        } catch(Exception exception) {
+            LOG.debug("Exception while trying to fix transport default value", exception);
+        }
+    }
+
+    @Override
+    public void start() {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/modules/enterprise/server/plugins/alert-snmp/src/main/java/org/rhq/enterprise/server/plugins/alertSnmp/SnmpTrapSender.java
+++ b/modules/enterprise/server/plugins/alert-snmp/src/main/java/org/rhq/enterprise/server/plugins/alertSnmp/SnmpTrapSender.java
@@ -81,8 +81,6 @@ import org.rhq.core.util.StringUtil;
 @SuppressWarnings("unused")
 public class SnmpTrapSender implements PDUFactory {
     public static final int DEFAULT = 0;
-    private static final String UDP_TRANSPORT = "udp";
-    private static final String TCP_TRANSPORT = "tcp";
     private static final String DEFAULT_RHQ_BINDING = "1.3.6.1.4.1.18016.2.1";
 
     private Log log = LogFactory.getLog(SnmpTrapSender.class);
@@ -368,13 +366,13 @@ public class SnmpTrapSender implements PDUFactory {
             port = 162; // just to make sure
         }
 
-        String transport = systemConfig.getSimpleValue("transport","UDP");
+        String transport = systemConfig.getSimpleValue(SNMPComponent.PROP_TRANSPORT, SNMPComponent.DEFAULT_TRANSPORT);
 
 
         String address = host + "/" + port;
-        if (transport.equalsIgnoreCase(UDP_TRANSPORT)) {
+        if (transport.equalsIgnoreCase(SNMPComponent.TRANSPORT_UDP)) {
             return new UdpAddress(address);
-        } else if (transport.equalsIgnoreCase(TCP_TRANSPORT)) {
+        } else if (transport.equalsIgnoreCase(SNMPComponent.TRANSPORT_TCP)) {
             return new TcpAddress(address);
         }
 

--- a/modules/enterprise/server/plugins/alert-snmp/src/main/resources/META-INF/rhq-serverplugin.xml
+++ b/modules/enterprise/server/plugins/alert-snmp/src/main/resources/META-INF/rhq-serverplugin.xml
@@ -14,6 +14,7 @@
         Used to send notifications to SNMP trap receivers.
     </serverplugin:help>
 
+    <serverplugin:plugin-component class="SNMPComponent"/>
 
     <!-- Global preferences for all snmp alerts -->
     <serverplugin:plugin-configuration>


### PR DESCRIPTION
This checks everytime a `ServerPlugin` is initialized if we have a valid value for the transport if not, writes the default configuration onto the database.
// cc @loleary 