### PR TITLE
Remove browser type gecko, no longer supported

### DIFF
--- a/etc/m2/settings.xml
+++ b/etc/m2/settings.xml
@@ -252,7 +252,7 @@
         <!-- set browser(s) to compile the GWT stuff for
           ~~ See https://docs.jboss.org/author/display/RHQ/Advanced+Build+Notes#AdvancedBuildNotes-GWTCompilationForDifferentBrowsers
           ~~ for details and browser versions
-          ~~ Possible values are: ie6,ie8,ie9,gecko,gecko1_8,safari,opera
+          ~~ Possible values are: ie6,ie8,ie9,gecko1_8,safari,opera
         -->
         <gwt.userAgent>SET_ME</gwt.userAgent>
         <!-- Only gwt-compile JavaScript for FF2 and later. -->


### PR DESCRIPTION
'gecko' type browser option (such as: <gwt.userAgent>gecko</gwt.userAgent>) causes build to fail as gecko is no-longer supported by GWT. Documented in Bugzilla 1487480 (https://bugzilla.redhat.com/show_bug.cgi?id=1487480).
https://stackoverflow.com/a/7992793/6328995
https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/useragent/UserAgent.gwt.xml