### PR TITLE
Bug 1455091 - Uses configuration being sent instead of fetching

### DIFF
--- a/modules/enterprise/server/plugins/alert-snmp/src/main/java/org/rhq/enterprise/server/plugins/alertSnmp/SNMPComponent.java
+++ b/modules/enterprise/server/plugins/alert-snmp/src/main/java/org/rhq/enterprise/server/plugins/alertSnmp/SNMPComponent.java
@@ -34,7 +34,8 @@ public class SNMPComponent implements ServerPluginComponent {
                 if (transportValue == null || !VALID_TRANSPORTS.contains(transportValue)) {
                     ServerPluginManagerLocal spm = LookupUtil.getServerPluginManager();
                     ServerPlugin serverPlugin  = spm.getServerPlugin(context.getPluginEnvironment().getPluginKey());
-                    serverPlugin.getPluginConfiguration().setSimpleValue(PROP_TRANSPORT, DEFAULT_TRANSPORT);
+                    configuration.setSimpleValue(PROP_TRANSPORT, DEFAULT_TRANSPORT);
+                    serverPlugin.setPluginConfiguration(configuration);
                     LookupUtil.getServerPluginManager().updateServerPluginExceptContent(
                             LookupUtil.getSubjectManager().getOverlord(),
                             serverPlugin


### PR DESCRIPTION
I was getting `could not initialize proxy - no Session` when trying to load the configuration from the ServerPlugin. That issue wasn't showing on RHQ.
I build this plugin on RHQ and installed it on JON, and was working as expected with this change.