### PR TITLE
Bug 1328540 - Fail when trying to secure setup CLI with an incompatib…

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseServerComponent.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/BaseServerComponent.java
@@ -481,6 +481,10 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
                     message += " (using vault)";
                     m = config.configureSecurityUsingVault(getHostConfig());
                 }
+                if (m != null) {
+                    result.setErrorMessage(m);
+                    return result;
+                }
                 madeChanges |= m == null;
                 response.append(m == null ? message : "Security skipped: " + m);
                 response.append("\n");


### PR DESCRIPTION
…le setup

[jbossas7]

Setup CLI operation will fail in the following cases:

Store Password Method: Plain
  1) Truststore path is not set
  2) Secure connection is not enabled
Store Password Method: Vault
  3) Vault definition was not found in server configuration file
  4) Could not find ssl configuration for management interface
  5) Cannot store truststore passwords using vault, because it is not supported by this version of EAP