### PR TITLE
Bug 1538697 - Allow to specify if manually imported EAP as local

### DIFF
--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
@@ -505,14 +505,18 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         HostConfiguration hostConfig;
         try {
             hostConfig = loadHostConfiguration(hostXmlFile);
+        } catch (Exception exception) {
+            LOG.info("Manually imported server marked as [REMOTE]. Unable to load configuration file: [" + hostXmlFile.getPath() + "]", exception);
+            hostConfig = null;
+        }
+        if (hostConfig != null) {
             serverPluginConfig.setApiVersion(hostConfig.getDomainApiVersion());
             pluginConfig.setSimpleValue("hostXmlFileName", hostXmlFile.getName());
             key = createKeyForLocalResource(serverPluginConfig);
             name = buildDefaultResourceName(hostPort, managementHostPort, productType, hostConfig.getHostName());
             version = getVersion(homeDir, productType);
             serverPluginConfig.setLocal(true);
-        } catch (Exception exception){
-            LOG.info("Manually imported server marked as [REMOTE]. Unable to load configuration file: [" + hostXmlFile.getPath() + "]", exception);
+        } else {
             hostPort.isLocal = false;
             managementHostPort.isLocal = false;
             serverPluginConfig.setLocal(false);

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseProcessDiscovery.java
@@ -58,6 +58,7 @@ import org.rhq.core.system.ProcessInfo;
 import org.rhq.modules.plugins.wildfly10.helper.HostConfiguration;
 import org.rhq.modules.plugins.wildfly10.helper.HostPort;
 import org.rhq.modules.plugins.wildfly10.helper.ServerPluginConfiguration;
+import org.rhq.modules.plugins.wildfly10.json.Address;
 import org.rhq.modules.plugins.wildfly10.json.Operation;
 import org.rhq.modules.plugins.wildfly10.json.ReadAttribute;
 import org.rhq.modules.plugins.wildfly10.json.Result;
@@ -214,6 +215,8 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         serverPluginConfig.setProductType(productType);
         pluginConfig.setSimpleValue("expectedRuntimeProductName", productType.PRODUCT_NAME);
         pluginConfig.setSimpleValue("hostXmlFileName", getHostXmlFileName(commandLine));
+
+        serverPluginConfig.setLocal(Boolean.TRUE);
 
         ProcessInfo agentProcess = discoveryContext.getSystemInformation().getThisProcess();
         setStartScriptPluginConfigProps(process, commandLine, pluginConfig, agentProcess);
@@ -468,14 +471,63 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
                 + "] as user [" + user + "]. Did you provide the correct credentials?");
         }
 
-        HostPort hostPort = new HostPort(false);
-        HostPort managementHostPort = new HostPort(false);
+        boolean isLocal = serverPluginConfig.isLocal();
+
+        HostPort hostPort = new HostPort(isLocal);
+        HostPort managementHostPort = new HostPort(isLocal);
         managementHostPort.host = hostname;
         managementHostPort.port = port;
-        String key = createKeyForRemoteResource(hostname + ":" + port);
-        String name = buildDefaultResourceName(hostPort, managementHostPort, productType, null);
-        //FIXME this is inconsistent with how the version looks like when autodiscovered
-        String version = productInfo.getProductVersion();
+        hostPort.port = HostConfiguration.DEFAULT_NATIVE_PORT;
+        String key, name, version;
+        if (isLocal) {
+            // Assume the server is local and follow a similar flow as if it was auto-discovered
+            ASConnection connection = new ASConnection(ASConnectionParams.createFrom(serverPluginConfig));
+            File homeDir = serverPluginConfig.getHomeDir();
+            if (homeDir == null) {
+                homeDir = getHomeDirFromConnection(connection);
+                serverPluginConfig.setHomeDir(homeDir);
+            }
+            if (serverPluginConfig.getBaseDir() == null) {
+                serverPluginConfig.setBaseDir(getBaseDirFromConnection(connection));
+            }
+            if (serverPluginConfig.getConfigDir() == null) {
+                serverPluginConfig.setConfigDir(getConfigDirFromConnection(connection));
+            }
+
+            File hostXmlFile = serverPluginConfig.getHostConfigFile();
+            if (hostXmlFile == null) {
+                hostXmlFile = getHostXmlFileFromConnection(connection);
+                serverPluginConfig.setHostConfigFile(hostXmlFile);
+            }
+            File logDir = serverPluginConfig.getLogDir();
+            if (logDir == null) {
+                logDir = getLogDirFromConnection(connection);
+                serverPluginConfig.setLogDir(logDir);
+            }
+            File logFile = getLogFile(logDir);
+            initLogEventSourcesConfigProp(logFile.getPath(), pluginConfig);
+
+            HostConfiguration hostConfig;
+            try {
+                hostConfig = loadHostConfiguration(hostXmlFile);
+            } catch (Exception exception){
+                throw new InvalidPluginConfigurationException(
+                        "Unable to load configuration file:" + hostXmlFile.getPath(),
+                        exception);
+            }
+            serverPluginConfig.setApiVersion(hostConfig.getDomainApiVersion());
+            pluginConfig.setSimpleValue("hostXmlFileName", hostXmlFile.getName());
+
+            key = createKeyForLocalResource(serverPluginConfig);
+            name = buildDefaultResourceName(hostPort, managementHostPort, productType, hostConfig.getHostName());
+            version = getVersion(homeDir, productType);
+        } else {
+            key = createKeyForRemoteResource(hostname + ":" + port);
+            name = buildDefaultResourceName(hostPort, managementHostPort, productType, null);
+            //FIXME this is inconsistent with how the version looks like when autodiscovered
+            version = productInfo.getProductVersion();
+        }
+
         String description = buildDefaultResourceDescription(hostPort, productType);
 
         pluginConfig.put(new PropertySimple("manuallyAdded", true));
@@ -486,6 +538,31 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
             description, pluginConfig, null);
 
         return detail;
+    }
+
+    private File getFileFromServerEnvironment(ASConnection connection, String environment) {
+        String file = getServerEnvironment(connection, environment);
+        return new File(FileUtils.getCanonicalPath(file));
+    }
+
+    private File getHomeDirFromConnection(ASConnection connection) {
+        return getFileFromServerEnvironment(connection, "home-dir");
+    }
+
+    private File getBaseDirFromConnection(ASConnection connection) {
+        return getFileFromServerEnvironment(connection, "base-dir");
+    }
+
+    private File getConfigDirFromConnection(ASConnection connection) {
+        return getFileFromServerEnvironment(connection, "config-dir");
+    }
+
+    private File getHostXmlFileFromConnection(ASConnection connection) {
+        return getFileFromServerEnvironment(connection, "config-file");
+    }
+
+    private File getLogDirFromConnection(ASConnection connection) {
+        return getFileFromServerEnvironment(connection, "log-dir");
     }
 
     private String createKeyForRemoteResource(String hostPort) {
@@ -510,6 +587,18 @@ public abstract class BaseProcessDiscovery implements ResourceDiscoveryComponent
         if (!res.isSuccess()) {
             throw new InvalidPluginConfigurationException("Could not connect to remote server ["
                 + res.getFailureDescription() + "]. Did you enable management?");
+        }
+        @SuppressWarnings("unchecked")
+        T result = (T) res.getResult();
+        return result;
+    }
+
+    private <T> T getServerEnvironment(ASConnection connection, String environment) {
+        Operation op = new ReadAttribute(new Address("core-service", "server-environment"), environment);
+        Result res = connection.execute(op);
+        if (!res.isSuccess()) {
+            throw new InvalidPluginConfigurationException("Could not connect to remote server ["
+                    + res.getFailureDescription() + "]. Did you enable management?");
         }
         @SuppressWarnings("unchecked")
         T result = (T) res.getResult();

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseServerComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/BaseServerComponent.java
@@ -499,19 +499,15 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
         OperationResult result = new OperationResult();
 
         if (isManuallyAddedServer()) {
-            if (!getServerPluginConfiguration().isLocal()) {
-                result.setErrorMessage("Operation not enabled on manually configured non local servers");
-                return result;
-            }
             File homeDir = serverPluginConfig.getHomeDir();
             if (!homeDir.exists()) {
-                result.setErrorMessage("Operation not enabled on servers without a valid Home Directory");
+                result.setErrorMessage("Operation not enabled on servers without a valid Home Directory: [" + homeDir + "]");
                 return result;
             }
             File jbossCli = new File(new File(homeDir, "bin"), getMode().getCliScriptFileName());
             if (!jbossCli.exists() || !jbossCli.canExecute()) {
                 result.setErrorMessage(getMode().getCliScriptFileName() +
-                        " not found on Home Directory or is not executable");
+                        " not found on Home Directory(" + homeDir + ") or is not executable");
                 return result;
             }
         }
@@ -697,12 +693,6 @@ public abstract class BaseServerComponent<T extends ResourceComponent<?>> extend
         String password = parameters.getSimpleValue("password", "");
 
         OperationResult result = new OperationResult();
-
-        if (isManuallyAddedServer() && !getServerPluginConfiguration().isLocal()) {
-            result.setErrorMessage(
-                    "This is a manually and not local added server. This operation can not be used to install a management user. Use the server's 'bin/add-user.sh'");
-            return result;
-        }
 
         if (user.isEmpty() || password.isEmpty()) {
             result.setErrorMessage("User and Password must not be empty");

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/WebRuntimeDiscoveryComponent.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/WebRuntimeDiscoveryComponent.java
@@ -74,7 +74,7 @@ public class WebRuntimeDiscoveryComponent extends VersionedRuntimeDiscovery {
 
     private void discoverResponseTimeLogFile(BaseServerComponent serverComponent, Configuration pluginConfig,
         String nodePath, String contextRoot) {
-        if (serverComponent.isManuallyAddedServer()) {
+        if (serverComponent.isManuallyAddedServer() && !serverComponent.getServerPluginConfiguration().isLocal()) {
             return;
         }
         String rtFilePath = null;

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
@@ -76,7 +76,7 @@ public class ServerPluginConfiguration {
     }
 
     /**
-     * returns detected path based on given path name 
+     * returns detected path based on given path name
      * @see <a href="https://docs.jboss.org/author/display/AS7/Admin+Guide#AdminGuide-Paths">https://docs.jboss.org/author/display/AS7/Admin+Guide#AdminGuide-Paths</a>
      * @param pathName - is path name defined in AS7 config xml file
      * @return File representing absolute path, return null if given pathName is not known

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
@@ -45,6 +45,7 @@ public class ServerPluginConfiguration {
         public static final String PASSWORD = "password";
         public static final String MANAGEMENT_CONNECTION_TIMEOUT = "managementConnectionTimeout";
         public static final String DEPLOYMENT_CONNECTION_TIMEOUT = "deploymentConnectionTimeout";
+        public static final String LOCAL = "local";
         public static final String HOME_DIR = "homeDir";
         public static final String BASE_DIR = "baseDir";
         public static final String CONFIG_DIR = "configDir";
@@ -156,6 +157,14 @@ public class ServerPluginConfiguration {
 
     public Long getManagementConnectionTimeout() {
         return this.pluginConfig.getSimple(Property.MANAGEMENT_CONNECTION_TIMEOUT).getLongValue();
+    }
+
+    public Boolean isLocal() {
+        return this.pluginConfig.getSimple(Property.LOCAL).getBooleanValue();
+    }
+
+    public void setLocal(boolean isLocal) {
+        this.pluginConfig.setSimpleValue(Property.LOCAL, String.valueOf(isLocal));
     }
 
     public File getHomeDir() {

--- a/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
@@ -1496,7 +1496,6 @@
       <c:simple-property name="password" type="password" description="Password for the management user" required="false"/>
       <c:simple-property name="managementConnectionTimeout" type="long" description="Maximum time in milliseconds to keep alive an idle management connection. Zero and negative values will disable connection persistence. Defaults to 5000 ms." required="false" default="5000"/>
       <c:simple-property name="deploymentConnectionTimeout" type="long" description="Maximum time in milliseconds to deploy new content. Defaults to 600000 ms." required="false" default="600000"/>
-      <c:simple-property name="local" displayName="Local server" type="boolean" description="Specifies if the server is know to be running local to the agent" required="false" default="false"/>
       <c:simple-property name="homeDir" type="file" description="Root directory of the server installation" displayName="Home Directory" readOnly="true" required="false"/>
       <c:simple-property name="baseDir" type="file" description="Base directory for server content" displayName="Base Directory" readOnly="true" required="false"/>
       <c:simple-property name="configDir" type="file" description="Base configuration directory" displayName="Configuration Directory" readOnly="true" required="false"/>

--- a/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
+++ b/modules/plugins/wfly-10/src/main/resources/META-INF/rhq-plugin.xml
@@ -1496,6 +1496,7 @@
       <c:simple-property name="password" type="password" description="Password for the management user" required="false"/>
       <c:simple-property name="managementConnectionTimeout" type="long" description="Maximum time in milliseconds to keep alive an idle management connection. Zero and negative values will disable connection persistence. Defaults to 5000 ms." required="false" default="5000"/>
       <c:simple-property name="deploymentConnectionTimeout" type="long" description="Maximum time in milliseconds to deploy new content. Defaults to 600000 ms." required="false" default="600000"/>
+      <c:simple-property name="local" displayName="Local server" type="boolean" description="Specifies if the server is know to be running local to the agent" required="false" default="false"/>
       <c:simple-property name="homeDir" type="file" description="Root directory of the server installation" displayName="Home Directory" readOnly="true" required="false"/>
       <c:simple-property name="baseDir" type="file" description="Base directory for server content" displayName="Base Directory" readOnly="true" required="false"/>
       <c:simple-property name="configDir" type="file" description="Base configuration directory" displayName="Configuration Directory" readOnly="true" required="false"/>


### PR DESCRIPTION
  Importing local EAPs follow a similar flow as the autodiscovery
  and are allowed to use operations.

--
Note: You can't manual import (Marking them as "Local") a resource that has been autodiscovered, because they share the same id.

To bypass this, one can, rename $JBOSS_HOME folder, start and manually import before the next autodiscovery.

edit:
Removed the "local" attribute. Now it tries to load the manually imported resource as "local", and falls back to "remote" if can't find all the required information.
A "remote" server can't execute some operations (because we need access to some files).