### PR TITLE
Bug 1537720, 1538697 - Adds default value for isLocal

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/ServerPluginConfiguration.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/helper/ServerPluginConfiguration.java
@@ -182,7 +182,7 @@ public class ServerPluginConfiguration {
     }
 
     public Boolean isLocal() {
-        return this.pluginConfig.getSimple(Property.LOCAL).getBooleanValue();
+        return Boolean.valueOf(this.pluginConfig.getSimpleValue(Property.LOCAL, "false"));
     }
 
     public void setLocal(boolean isLocal) {

--- a/modules/plugins/jboss-as-7/src/test/java/org/rhq/modules/plugins/jbossas7/WebRuntimeDiscoveryComponentTest.java
+++ b/modules/plugins/jboss-as-7/src/test/java/org/rhq/modules/plugins/jbossas7/WebRuntimeDiscoveryComponentTest.java
@@ -150,10 +150,12 @@ public class WebRuntimeDiscoveryComponentTest {
     }
 
     @Test
-    public void shouldNotFindResponseTimeFilterLogInManuallyAddedStandaloneServer() throws Exception {
+    public void shouldNotFindResponseTimeFilterLogInManuallyAddedNotLocalStandaloneServer() throws Exception {
         when(parentResourceComponent.getPath()).thenReturn(PARENT_COMPONENT_PATH_IN_STANDALONE_SERVER);
         when(parentResourceComponent.getServerComponent()).thenReturn(standaloneASComponent);
         when(standaloneASComponent.isManuallyAddedServer()).thenReturn(Boolean.TRUE);
+        ServerPluginConfiguration standaloneServerPLuginConfig = createStandaloneServerPluginConfig();
+        when(standaloneASComponent.getServerPluginConfiguration()).thenReturn(standaloneServerPLuginConfig);
 
         Set<DiscoveredResourceDetails> details = discoveryComponent.discoverResources(discoveryContext);
         assertNotNull(details);
@@ -200,10 +202,12 @@ public class WebRuntimeDiscoveryComponentTest {
     }
 
     @Test
-    public void shouldNotFindResponseTimeFilterLogInManuallyAddedManagedServer() throws Exception {
+    public void shouldNotFindResponseTimeFilterLogInManuallyAddedNotLocalManagedServer() throws Exception {
         when(parentResourceComponent.getPath()).thenReturn(PARENT_COMPONENT_PATH_IN_MANAGED_SERVER);
         when(parentResourceComponent.getServerComponent()).thenReturn(hostControllerComponent);
         when(hostControllerComponent.isManuallyAddedServer()).thenReturn(Boolean.TRUE);
+        ServerPluginConfiguration hostControllerServerPluginConfig = createHostControllerServerPluginConfig();
+        when(hostControllerComponent.getServerPluginConfiguration()).thenReturn(hostControllerServerPluginConfig);
 
         Set<DiscoveredResourceDetails> details = discoveryComponent.discoverResources(discoveryContext);
         assertNotNull(details);

--- a/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
+++ b/modules/plugins/wfly-10/src/main/java/org/rhq/modules/plugins/wildfly10/helper/ServerPluginConfiguration.java
@@ -160,7 +160,8 @@ public class ServerPluginConfiguration {
     }
 
     public Boolean isLocal() {
-        return this.pluginConfig.getSimple(Property.LOCAL).getBooleanValue();
+        return Boolean.valueOf(this.pluginConfig.getSimpleValue(Property.LOCAL, "false"));
+
     }
 
     public void setLocal(boolean isLocal) {

--- a/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/WebRuntimeDiscoveryComponentTest.java
+++ b/modules/plugins/wfly-10/src/test/java/org/rhq/modules/plugins/wildfly10/WebRuntimeDiscoveryComponentTest.java
@@ -150,10 +150,12 @@ public class WebRuntimeDiscoveryComponentTest {
     }
 
     @Test
-    public void shouldNotFindResponseTimeFilterLogInManuallyAddedStandaloneServer() throws Exception {
+    public void shouldNotFindResponseTimeFilterLogInManuallyAddedNotLocalStandaloneServer() throws Exception {
         when(parentResourceComponent.getPath()).thenReturn(PARENT_COMPONENT_PATH_IN_STANDALONE_SERVER);
         when(parentResourceComponent.getServerComponent()).thenReturn(standaloneASComponent);
         when(standaloneASComponent.isManuallyAddedServer()).thenReturn(Boolean.TRUE);
+        ServerPluginConfiguration standaloneServerPluginConfig = createStandaloneServerPluginConfig();
+        when(standaloneASComponent.getServerPluginConfiguration()).thenReturn(standaloneServerPluginConfig);
 
         Set<DiscoveredResourceDetails> details = discoveryComponent.discoverResources(discoveryContext);
         assertNotNull(details);
@@ -200,10 +202,12 @@ public class WebRuntimeDiscoveryComponentTest {
     }
 
     @Test
-    public void shouldNotFindResponseTimeFilterLogInManuallyAddedManagedServer() throws Exception {
+    public void shouldNotFindResponseTimeFilterLogInManuallyAddedNotLocalManagedServer() throws Exception {
         when(parentResourceComponent.getPath()).thenReturn(PARENT_COMPONENT_PATH_IN_MANAGED_SERVER);
         when(parentResourceComponent.getServerComponent()).thenReturn(hostControllerComponent);
         when(hostControllerComponent.isManuallyAddedServer()).thenReturn(Boolean.TRUE);
+        ServerPluginConfiguration hostControllerServerPluginConfig = createHostControllerServerPluginConfig();
+        when(hostControllerComponent.getServerPluginConfiguration()).thenReturn(hostControllerServerPluginConfig);
 
         Set<DiscoveredResourceDetails> details = discoveryComponent.discoverResources(discoveryContext);
         assertNotNull(details);


### PR DESCRIPTION
Also Fix tests related to manually adding a server

It was failing because two things:

- We didn't mock the `getServerPluginConfiguration` method, it wasn't being used on these tests.
- We didn't provide a default value in case "isLocal" is `null`, this could happen when importing using an old version and then upgrading, defaults to False, old versions always used the "Remote" path.