### PR TITLE
Bug 1542125 - Allows rest user to logout to be able to refresh its permissions

### DIFF
--- a/modules/common/jboss-as-dmr-client/src/main/java/org/rhq/common/jbossas/client/controller/InfinispanJBossASClient.java
+++ b/modules/common/jboss-as-dmr-client/src/main/java/org/rhq/common/jbossas/client/controller/InfinispanJBossASClient.java
@@ -32,6 +32,16 @@ public class InfinispanJBossASClient extends JBossASClient {
     public static final String SUBSYSTEM_INFINISPAN = "infinispan";
     public static final String CACHE_CONTAINER = "cache-container";
     public static final String LOCAL_CACHE = "local-cache";
+    public static final String SECURITY = "security";
+    public static final String AUTH_CACHE = "auth-cache";
+    public static final String DEFAULT_CACHE = "default-cache";
+    public static final String EVICTION = "eviction";
+    public static final String STRATEGY = "strategy";
+    public static final String MAX_ENTRIES = "max-entries";
+    public static final String EXPIRATION = "expiration";
+    public static final String MAX_IDLE = "max-idle";
+    public static final String LIFESPAN = "lifespan";
+    public static final String JNDI_NAME = "jndi-name";
 
     public InfinispanJBossASClient(ModelControllerClient client) {
         super(client);
@@ -47,6 +57,61 @@ public class InfinispanJBossASClient extends JBossASClient {
         Address addr = Address.root().add(SUBSYSTEM, SUBSYSTEM_INFINISPAN);
         String haystack = CACHE_CONTAINER;
         return null != findNodeInList(addr, haystack, cacheContainerName);
+    }
+
+    /**
+     * Removes the cacheContainerName if it exists
+     *
+     * @param cacheContainerName the name of the cache container
+     * @throws Exception
+     */
+    public void removeCacheContainer(String cacheContainerName) throws Exception {
+        // If not there just return
+        if (!isCacheContainer(cacheContainerName)) {
+            return;
+        }
+
+        final Address addr = Address.root().add(SUBSYSTEM, SUBSYSTEM_INFINISPAN, CACHE_CONTAINER, cacheContainerName);
+        ModelNode removeCacheContainerNode = createRequest(REMOVE, addr);
+
+        final ModelNode results = execute(removeCacheContainerNode);
+        if (!isSuccess(results)) {
+            throw new FailureException(results, "Failed to remove cache container [" + cacheContainerName + "]");
+        }
+
+        return;
+    }
+
+    public void createSecurityDomainInfinispanCache(String evictionStrategy, int evictionMaxEntries, Long expirationMaxIdle, Long expirationLifespan) throws Exception {
+
+        removeCacheContainer(SECURITY);
+
+        Address addr = Address.root().add(SUBSYSTEM, SUBSYSTEM_INFINISPAN, CACHE_CONTAINER, SECURITY);
+
+        String jndiName = "java:jboss/infinispan/" + SECURITY;
+
+        ModelNode addTopNode = createRequest(ADD, addr);
+        addTopNode.get(DEFAULT_CACHE).set(AUTH_CACHE);
+        addTopNode.get(JNDI_NAME).set(jndiName);
+
+        Address localCacheAddr = addr.clone().add(LOCAL_CACHE, AUTH_CACHE);
+
+        ModelNode addLocalCache = createRequest(ADD, localCacheAddr);
+
+        ModelNode addEviction = createRequest(ADD, localCacheAddr.clone().add(EVICTION, EVICTION.toUpperCase()));
+        addEviction.get(STRATEGY).set(evictionStrategy);
+        addEviction.get(MAX_ENTRIES).set(evictionMaxEntries);
+
+        ModelNode addExpiration = createRequest(ADD, localCacheAddr.clone().add(EXPIRATION, EXPIRATION.toUpperCase()));
+        addExpiration.get(MAX_IDLE).set(expirationMaxIdle);
+        addExpiration.get(LIFESPAN).set(expirationLifespan);
+
+        ModelNode batch = createBatchRequest(addTopNode, addLocalCache, addEviction, addExpiration);
+        ModelNode results = execute(batch);
+        if (!isSuccess(results)) {
+            throw new FailureException(results, "Failed to create infinispan cache [" + SECURITY + "]");
+        }
+        return;
     }
 
     /**

--- a/modules/common/jboss-as-dmr-client/src/main/java/org/rhq/common/jbossas/client/controller/SecurityDomainJBossASClient.java
+++ b/modules/common/jboss-as-dmr-client/src/main/java/org/rhq/common/jbossas/client/controller/SecurityDomainJBossASClient.java
@@ -270,19 +270,23 @@ public class SecurityDomainJBossASClient extends JBossASClient {
      * @throws Exception if failed to create security domain
      */
     public void createNewSecurityDomain(String securityDomainName, LoginModuleRequest... loginModules) throws Exception {
+        createNewSecurityDomain(securityDomainName, false, loginModules);
+    }
+
+    public void createNewSecurityDomain(String securityDomainName, boolean useInfinispanCache, LoginModuleRequest... loginModules) throws Exception {
         //do not close the controller client here, we're using our own..
         CoreJBossASClient coreClient = new CoreJBossASClient(getModelControllerClient());
         String serverVersion = coreClient.getAppServerVersion();
         if (serverVersion.startsWith("7.2")) {
-            createNewSecurityDomain72(securityDomainName, loginModules);
+            createNewSecurityDomain72(securityDomainName, useInfinispanCache, loginModules);
         }
         else {
-            createNewSecurityDomain71(securityDomainName,loginModules);
+            createNewSecurityDomain71(securityDomainName, useInfinispanCache, loginModules);
         }
 
     }
 
-    private void createNewSecurityDomain71(String securityDomainName, LoginModuleRequest... loginModules) throws Exception {
+    private void createNewSecurityDomain71(String securityDomainName, boolean useInfinispanCache, LoginModuleRequest... loginModules) throws Exception {
 
         if (isSecurityDomain(securityDomainName)) {
             removeSecurityDomain(securityDomainName);
@@ -291,7 +295,7 @@ public class SecurityDomainJBossASClient extends JBossASClient {
         Address addr = Address.root().add(SUBSYSTEM, SUBSYSTEM_SECURITY, SECURITY_DOMAIN, securityDomainName);
 
         ModelNode addTopNode = createRequest(ADD, addr);
-        addTopNode.get(CACHE_TYPE).set("default");
+        addTopNode.get(CACHE_TYPE).set(useInfinispanCache? "infinispan" : "default");
 
         ModelNode addAuthNode = createRequest(ADD, addr.clone().add(AUTHENTICATION, CLASSIC));
         ModelNode loginModulesNode = addAuthNode.get(LOGIN_MODULES);
@@ -325,7 +329,7 @@ public class SecurityDomainJBossASClient extends JBossASClient {
         return;
     }
 
-    private void createNewSecurityDomain72(String securityDomainName, LoginModuleRequest... loginModules) throws Exception {
+    private void createNewSecurityDomain72(String securityDomainName, boolean useInfinispanCache, LoginModuleRequest... loginModules) throws Exception {
 
         if (isSecurityDomain(securityDomainName)) {
             removeSecurityDomain(securityDomainName);
@@ -334,7 +338,7 @@ public class SecurityDomainJBossASClient extends JBossASClient {
         Address addr = Address.root().add(SUBSYSTEM, SUBSYSTEM_SECURITY, SECURITY_DOMAIN, securityDomainName);
 
         ModelNode addTopNode = createRequest(ADD, addr);
-        addTopNode.get(CACHE_TYPE).set("default");
+        addTopNode.get(CACHE_TYPE).set(useInfinispanCache ? "infinispan" : "default");
 
         Address authAddr = addr.clone().add(AUTHENTICATION, CLASSIC);
         ModelNode addAuthNode = createRequest(ADD, authAddr);

--- a/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/ServerInstallUtil.java
+++ b/modules/enterprise/server/installer/src/main/java/org/rhq/enterprise/server/installer/ServerInstallUtil.java
@@ -406,7 +406,11 @@ public class ServerInstallUtil {
             DELEGATING_LOGIN_MODULE_NAME, AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT, options);
 
         SecurityDomainJBossASClient client = new SecurityDomainJBossASClient(mcc);
-        client.createNewSecurityDomain(RHQ_REST_SECURITY_DOMAIN, loginModuleRequest);
+        InfinispanJBossASClient infinispanClient = new InfinispanJBossASClient(mcc);
+
+        // Create the cache used for the rest security domain
+        infinispanClient.createSecurityDomainInfinispanCache("LRU", 1000, 200000L, 900000L);
+        client.createNewSecurityDomain(RHQ_REST_SECURITY_DOMAIN, true, loginModuleRequest);
     }
 
     /**

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/UserHandlerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/rest/UserHandlerBean.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.interceptor.Interceptors;
@@ -51,9 +52,11 @@ import com.wordnik.swagger.annotations.ApiErrors;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 
+import org.infinispan.manager.CacheContainer;
 import org.jboss.resteasy.annotations.GZIP;
 import org.jboss.resteasy.annotations.cache.Cache;
 
+import org.jboss.security.SimplePrincipal;
 import org.rhq.core.domain.auth.Subject;
 import org.rhq.core.domain.configuration.Configuration;
 import org.rhq.core.domain.configuration.PropertySimple;
@@ -94,6 +97,16 @@ public class UserHandlerBean extends AbstractRestBean {
 
     @EJB
     private ResourceManagerLocal resourceManager;
+
+    @javax.annotation.Resource( name = "ISPNsecurity", mappedName = "java:jboss/infinispan/security")
+    private CacheContainer cacheContainer;
+    protected org.infinispan.Cache<CacheKey, Object> authCache;
+
+    @PostConstruct
+    public void start() {
+        super.start();
+        this.authCache = this.cacheContainer.getCache("RHQRESTSecurityDomain");
+    }
 
     @GZIP
     @GET
@@ -289,6 +302,19 @@ public class UserHandlerBean extends AbstractRestBean {
 
         }
         return builder.build();
+    }
+
+    @GET
+    @Path("logout")
+    @ApiOperation(value = "Force a REST logout by clearing the user cache")
+    public void logout() {
+        SimplePrincipal principal = new SimplePrincipal(caller.getName());
+        log.debug("Forcing REST logout of user: [" + principal + "]");
+        Object cachedValue = this.authCache.remove(principal);
+        if (cachedValue != null) {
+            log.debug("REST user logged out: [" + principal + "]" );
+        }
+
     }
 
     private void updateResourceFavorites(Set<Integer> favIds) {


### PR DESCRIPTION
- Set SecurityDomain[RHQRESTSecurityDomain] cache-type to infinispan
 - Creates infinispan cache at server install
   (named security, which is what cache-type=infinispan uses)
 - Creates new endpoint /user/logout to force the removal of the
   logged user cache

Reverts https://github.com/rhq-project/rhq/commit/5837457f16bdd16d7c956bfbeb549de0fe478e13 (i.e. reverts the revert)

This make the following changes to `standalone-full.xml` while installing:

- security-domain name="RHQRESTSecurityDomain" cache-type is changed from `default` to `infinispan`
- The following `cache-container` is created:
```xml
<cache-container name="security" default-cache="auth-cache" jndi-name="java:jboss/infinispan/security">
    <local-cache name="auth-cache">
        <eviction strategy="LRU" max-entries="1000"/>
        <expiration max-idle="200000" lifespan="900000"/>
     </local-cache>
</cache-container>
```