### PR TITLE
BZ 1418034 - Try to update configurations instead of replace/delete it

### DIFF
--- a/modules/core/domain/src/main/java/org/rhq/core/domain/configuration/Configuration.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/configuration/Configuration.java
@@ -945,6 +945,15 @@ public class Configuration implements Serializable, Cloneable, AbstractPropertyM
         return copy;
     }
 
+    public void replaceWithConfig(Configuration config){
+        this.properties.clear();
+        rawConfigurations.clear();
+        this.notes = config.notes;
+        this.version = config.version;
+        config.createDeepCopyOfProperties(this, false);
+        config.createDeepCopyOfRawConfigs(this, false);
+    }
+
     public Configuration deepCopyWithoutProxies() {
         Configuration copy = new Configuration();
         copy.notes = this.notes;

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/ConfigurationManagerBean.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/configuration/ConfigurationManagerBean.java
@@ -226,9 +226,7 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
 
         // link to the newer, persisted configuration object -- regardless of errors
         resource.setAgentSynchronizationNeeded();
-        entityManager.remove(resource.getPluginConfiguration());
-        resource.setPluginConfiguration(update.getConfiguration().deepCopyWithoutProxies());
-
+        setOrUpdatePluginConfiguration(resource, update.getConfiguration());
         if (response.getStatus() == ConfigurationUpdateStatus.SUCCESS) {
             update.setStatus(ConfigurationUpdateStatus.SUCCESS);
 
@@ -343,8 +341,7 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
         entityManager.persist(update);
 
         resource.addPluginConfigurationUpdates(update);
-        entityManager.remove(resource.getPluginConfiguration());
-        resource.setPluginConfiguration(update.getConfiguration().deepCopyWithoutProxies());
+        setOrUpdatePluginConfiguration(resource, update.getConfiguration());
         return update;
     }
 
@@ -373,10 +370,26 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
         if (resource == null) {
             throw new ResourceNotFoundException("Resource [" + resourceId + "] does not exist.");
         }
-        entityManager.remove(resource.getResourceConfiguration());
-        resource.setResourceConfiguration(configuration);
+        setOrUpdateResourceConfiguration(resource, configuration);
     }
 
+    private void setOrUpdateResourceConfiguration(Resource resource, Configuration configuration) {
+        Configuration currentConfiguration = resource.getResourceConfiguration();
+        if(currentConfiguration != null && currentConfiguration.getId() != 0) {
+            currentConfiguration.replaceWithConfig(configuration);
+        } else {
+            resource.setResourceConfiguration(configuration.deepCopyWithoutProxies());
+        }
+    }
+
+    private void setOrUpdatePluginConfiguration(Resource resource, Configuration configuration) {
+        Configuration currentConfiguration = resource.getPluginConfiguration();
+       if(currentConfiguration != null && currentConfiguration.getId() != 0) {
+           currentConfiguration.replaceWithConfig(configuration);
+        } else {
+            resource.setPluginConfiguration(configuration.deepCopyWithoutProxies());
+        }
+    }
     // Use new transaction because this only works if the resource in question has not
     // yet been loaded by Hibernate.  We want the query to return a non-proxied configuration,
     // this is critical for remote API use.
@@ -542,7 +555,7 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
                 liveConfig, ConfigurationUpdateStatus.SUCCESS, null, false);
 
         // resource.setResourceConfiguration(liveConfig.deepCopy(false));
-        resource.setResourceConfiguration(liveConfig.deepCopyWithoutProxies());
+        setOrUpdateResourceConfiguration(resource, liveConfig);
         return update;
     }
 
@@ -1567,8 +1580,7 @@ public class ConfigurationManagerBean implements ConfigurationManagerLocal, Conf
         } else if (response.getStatus() == ConfigurationUpdateStatus.SUCCESS) {
             // link to the newer, persisted configuration object
             Resource resource = update.getResource();
-            entityManager.remove(resource.getResourceConfiguration());
-            resource.setResourceConfiguration(update.getConfiguration().deepCopyWithoutProxies());
+            setOrUpdateResourceConfiguration(resource, update.getConfiguration());
             notifyAlertConditionCacheManager("completeResourceConfigurationUpdate", update);
         }
 


### PR DESCRIPTION
I need to modify the initial solution proposed, that is due to a deadlock on Oracle DB when the deletion of the old configurations in a config replacement is performed.

This occurs because the there is a lot of FK pointing to RHQ_CONFIG table that doesn't have indices, so Oracle decides to acquire a lock for "child" tables. At some point, we have two transactions that have a shared lock and want to acquire an exclusive lock for some of those tables, but both need to wait to the other release the shared lock,  in that scenario we have a deadlock. This happens especially in high concurrent methods like `setResourceConfiguration`.

To avoid this, I prefer to do an update on the existing row, instead of a whole replacement of the config row. This is what I tried to do in this PR.

@josejulio Could you please help me reviewing and testing?

Thanks.

//cc: @jshaughn 
