### PR TITLE
[BZ-1647619] Added unsupported WILDFLY8 type back for compatibility

### DIFF
--- a/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/JBossProductType.java
+++ b/modules/plugins/jboss-as-7/src/main/java/org/rhq/modules/plugins/jbossas7/JBossProductType.java
@@ -36,6 +36,7 @@ public enum JBossProductType {
     JDG("JDG", "JBoss JDG 6", "JBoss Data Grid 6", "Data Grid"),
     JPP("JPP", "JBoss JPP 6", "JBoss Portal Platform 6", "Portal Platform"),
     SOA("SOA-P", "JBoss SOA-P 6", "Red Hat JBoss Fuse Service Works", "Red Hat JBoss Fuse Service Works"),
+    WILDFLY8("WildFly", "WildFly 8", "WildFly Application Server 8", "WildFly"),
     BRMS("BRMS", "JBoss BRMS", "Red Hat JBoss BRMS", "BRMS"),
     BPMS("BPM Suite", "JBoss BPM Suite", "Red Hat JBoss BPM Suite", "BPM Suite"),
     JDV("JDV", "Data Virt", "Red Hat JBoss Data Virtualization", "Red Hat JBoss Data Virtualization"),


### PR DESCRIPTION
JBossProductType.WILDFLY8 was removed as part of the work done in
BZ-1337983. As this type is part of the plug-in API, it should not have
been removed. This adds the type back in so that any references to the
type in previously released plug-ins will not fail.