### PR TITLE
[BZ 1719376] Use getProperties instead of direct access to properties attribute wh…

### DIFF
--- a/modules/core/domain/src/main/java/org/rhq/core/domain/configuration/Configuration.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/configuration/Configuration.java
@@ -974,7 +974,7 @@ public class Configuration implements Serializable, Cloneable, AbstractPropertyM
     }
 
     private void createDeepCopyOfProperties(Configuration copy, boolean keepId) {
-        for (Property property : this.properties.values()) {
+        for (Property property : this.getProperties()) {
             copy.put(property.deepCopy(keepId));
         }
     }


### PR DESCRIPTION
…en config is copied

When configuration is lazyloaded, we need to access to the properties using accessor method. In this way the data will be fetched if the object is "managed" by hibernate.